### PR TITLE
Fix query to handle fields with different types

### DIFF
--- a/src/elasticSearchService.ts
+++ b/src/elasticSearchService.ts
@@ -73,6 +73,7 @@ export class ElasticSearchService implements Search {
                         fields: [fieldParam],
                         query: queryParams[field],
                         default_operator: 'AND',
+                        lenient: true,
                     },
                 };
                 must.push(query);


### PR DESCRIPTION
Description of changes:

Some simple queries(i.e. `{{API_URL}}/Patient?name=Emily`) were failing with `search_phase_execution_exception` 

This was caused by wildcards in field names matching fields with different types.

For example, for Patient the field "name.*" matches "name.given" of type text  and "name.period.start" of type date.
The type mismatch was causing the query to fail.

ES has a convenient `lenient` flag that fixes the issue
https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-multi-field


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.