### PR TITLE
feat: Implement _include:iterate & _revinclude:iterate

### DIFF
--- a/src/__snapshots__/elasticSearchService.test.ts.snap
+++ b/src/__snapshots__/elasticSearchService.test.ts.snap
@@ -360,6 +360,95 @@ Array [
 ]
 `;
 
+exports[`typeSearch _include:iterate: msearch queries 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Array [
+        Object {
+          "index": "patient",
+        },
+        Object {
+          "query": Object {
+            "bool": Object {
+              "filter": Array [
+                Object {
+                  "terms": Object {
+                    "id": Array [
+                      "patient-id-333",
+                    ],
+                  },
+                },
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+  ],
+  Array [
+    Object {
+      "body": Array [
+        Object {
+          "index": "organization",
+        },
+        Object {
+          "query": Object {
+            "bool": Object {
+              "filter": Array [
+                Object {
+                  "terms": Object {
+                    "id": Array [
+                      "org-id-111",
+                    ],
+                  },
+                },
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+  ],
+]
+`;
+
+exports[`typeSearch _include:iterate: search queries 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [],
+          },
+        },
+      },
+      "from": 0,
+      "index": "medicationrequest",
+      "size": 20,
+    },
+  ],
+]
+`;
+
 exports[`typeSearch _revinclude queryParams={"_revinclude":"*"}: msearch queries 1`] = `
 Array [
   Array [
@@ -2503,6 +2592,95 @@ Array [
 `;
 
 exports[`typeSearch _revinclude queryParams={"_revinclude":["MedicationAdministration:request","Provenance:target"]}: search queries 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [],
+          },
+        },
+      },
+      "from": 0,
+      "index": "medicationrequest",
+      "size": 20,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch _revinclude:iterate: msearch queries 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Array [
+        Object {
+          "index": "medicationadministration",
+        },
+        Object {
+          "query": Object {
+            "bool": Object {
+              "filter": Array [
+                Object {
+                  "terms": Object {
+                    "request.reference.keyword": Array [
+                      "MedicationRequest/medicationrequest-id-111",
+                    ],
+                  },
+                },
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+  ],
+  Array [
+    Object {
+      "body": Array [
+        Object {
+          "index": "medicationstatement",
+        },
+        Object {
+          "query": Object {
+            "bool": Object {
+              "filter": Array [
+                Object {
+                  "terms": Object {
+                    "partOf.reference.keyword": Array [
+                      "MedicationAdministration/medication-administration-111",
+                    ],
+                  },
+                },
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+  ],
+]
+`;
+
+exports[`typeSearch _revinclude:iterate: search queries 1`] = `
 Array [
   Array [
     Object {


### PR DESCRIPTION
Description of changes:

These PR adds support for the `_include:iterate` and `_revinclude:iterate` search parameters

From the FHIR spec:

The inclusion process can be iterative, if (and only if) the modifier :iterate is included. For example, this search returns all Medication Request resources and their prescribing Practitioner Resources for the matching Medication Dispense resources:

```
GET [base]/MedicationDispense?_include=MedicationDispense:prescription&_include:iterate=MedicationRequest:performer&criteria...
```
This technique applies to circular relationships as well. For example, the first of these two searches includes any related observations to the target relationships, but only those directly related. The second search asks for the _include based on related parameter to be executed iteratively, so it will retrieve observations that are directly related, and also any related observations to any other included observation.

```
GET [base]/Observation?_include=Observation:related-target&criteria...
GET [base]/Observation?_include:iterate=Observation:related-target&criteria...
```
https://www.hl7.org/fhir/search.html

---
Evaluating `:iterate` inclusions is the last step of search since it operates on top of the resources found by regular search criteria and the resources found by regular _include/_revinclude

The basic idea is to run the already existing inclusion process iteratively, feeding the resources found by one iteration as the starting resources for the next one. Iterations stop once either:
- No more resources are found. This means that the inclusion process is complete
- `MAX_INCLUDE_ITERATIVE_DEPTH` is reached. This protects us from returning way too many results.
> Using iterative wildcards inclusions might lead to the retrieval of the full patient's record, or even more than that: resources are organized into an interlinked network and broad _include paths may eventually traverse all possible paths on the server.
It is at the server's discretion how deep to iteratively evaluate the inclusions. Servers are expected to limit the number of iterations done to an appropriate level and are not obliged to honor requests to include additional resources in the search results.

Other changes:

- include & revinclude queries are now sent together in a single call to ES. Less calls to ES is better.
- Updated several SearchInclusions functions to operate on multiple resource types at once. Before we could assume that all the resources matched the `requestResourceType`. This is no longer true for `:iterate`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.