### PR TITLE
feat: Support _id search parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.1.0] - 2020-09-28
+## [1.1.0] - 2020-09-30
 - feat: Implement _include and _revinclude search parameters
+- feat: Support _id search parameter
 
 ## [1.0.0] - 2020-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.1.0] - 2020-09-30
+## [1.1.0] - 2020-10-01
+
 - feat: Implement _include and _revinclude search parameters
 - feat: Support _id search parameter
 

--- a/src/__snapshots__/elasticSearchService.test.ts.snap
+++ b/src/__snapshots__/elasticSearchService.test.ts.snap
@@ -1372,6 +1372,43 @@ Array [
 ]
 `;
 
+exports[`typeSearch query snapshots for simple queryParams queryParams={"_id":"11111111-1111-1111-1111-111111111111"} 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [
+              Object {
+                "query_string": Object {
+                  "default_operator": "AND",
+                  "fields": Array [
+                    "id",
+                  ],
+                  "lenient": true,
+                  "query": "11111111-1111-1111-1111-111111111111",
+                },
+              },
+            ],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient",
+      "size": 20,
+    },
+  ],
+]
+`;
+
 exports[`typeSearch query snapshots for simple queryParams queryParams={"gender":"female","name":"Emily"} 1`] = `
 Array [
   Array [

--- a/src/elasticSearchService.test.ts
+++ b/src/elasticSearchService.test.ts
@@ -34,6 +34,7 @@ describe('typeSearch', () => {
             [{ _count: 10, _getpagesoffset: 2 }],
             [{ gender: 'female', name: 'Emily' }],
             [{ id: '11111111-1111-1111-1111-111111111111' }],
+            [{ _id: '11111111-1111-1111-1111-111111111111' }],
             [{ _format: 'json' }],
             [
                 {

--- a/src/searchInclusions.ts
+++ b/src/searchInclusions.ts
@@ -1,3 +1,7 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
 import { groupBy, mapValues, uniq, get, uniqBy } from 'lodash';
 
 import { FhirVersion } from 'fhir-works-on-aws-interface';

--- a/src/searchParametersMapping.ts
+++ b/src/searchParametersMapping.ts
@@ -1,0 +1,20 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+const SEARCH_PARAMETER_TO_DOCUMENT_FIELD = {
+    _id: 'id',
+    id: 'id',
+};
+
+const hasMapping = (searchParameter: string): searchParameter is keyof typeof SEARCH_PARAMETER_TO_DOCUMENT_FIELD => {
+    return searchParameter in SEARCH_PARAMETER_TO_DOCUMENT_FIELD;
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export const getDocumentField = (searchParameter: string) => {
+    if (hasMapping(searchParameter)) {
+        return SEARCH_PARAMETER_TO_DOCUMENT_FIELD[searchParameter];
+    }
+    return `${searchParameter}.*`;
+};


### PR DESCRIPTION
Description of changes:
Implement the `_id` search parameter as specified in https://www.hl7.org/fhir/search.html#id

Currently we do not support the FHIR resource specific search parameters (i.e. https://www.hl7.org/fhir/patient.html#search), but rather any search parameter provided is matched directly against document fields with the same name. For backwards compatibility, both `id` and `_id` are supported and have the same meaning.

both of the following search requests are equivalent:
```
{{API_URL}}/MedicationAdministration?_id=111
{{API_URL}}/MedicationAdministration?id=111
```

Related Item: FHIR-196

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.