### PR TITLE
refactor: Don't start iterative inclusion search if there are no iterative inclusion parameters

### DIFF
--- a/src/elasticSearchService.ts
+++ b/src/elasticSearchService.ts
@@ -275,7 +275,7 @@ export class ElasticSearchService implements Search {
     ): Promise<SearchEntry[]> {
         if (
             !ITERATIVE_INCLUSION_PARAMETERS.some(param => {
-                return Object.keys(request.queryParams).includes(param);
+                return Object.prototype.hasOwnProperty.call(request.queryParams, param);
             })
         ) {
             return [];

--- a/src/elasticSearchService.ts
+++ b/src/elasticSearchService.ts
@@ -275,7 +275,7 @@ export class ElasticSearchService implements Search {
     ): Promise<SearchEntry[]> {
         if (
             !ITERATIVE_INCLUSION_PARAMETERS.some(param => {
-                return Object.prototype.hasOwnProperty.call(request.queryParams, param);
+                return request.queryParams[param];
             })
         ) {
             return [];

--- a/src/elasticSearchService.ts
+++ b/src/elasticSearchService.ts
@@ -274,9 +274,9 @@ export class ElasticSearchService implements Search {
         request: TypeSearchRequest,
     ): Promise<SearchEntry[]> {
         if (
-            Object.keys(request.queryParams).filter(searchParam => {
-                return ITERATIVE_INCLUSION_PARAMETERS.includes(searchParam);
-            }).length === 0
+            !ITERATIVE_INCLUSION_PARAMETERS.some(param => {
+                return Object.keys(request.queryParams).includes(param);
+            })
         ) {
             return [];
         }


### PR DESCRIPTION
Description of changes:
Don't start iterative inclusion search if there are no iterative inclusion parameters

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.