### PR TITLE
feat: Implement date prefix based search

### DIFF
--- a/src/__snapshots__/elasticSearchService.test.ts.snap
+++ b/src/__snapshots__/elasticSearchService.test.ts.snap
@@ -110,7 +110,15 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [],
+            "filter": Array [
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
+            ],
             "must": Array [],
             "must_not": Array [],
           },
@@ -165,7 +173,15 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [],
+            "filter": Array [
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
+            ],
             "must": Array [],
             "must_not": Array [],
           },
@@ -188,7 +204,15 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [],
+            "filter": Array [
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
+            ],
             "must": Array [],
             "must_not": Array [],
           },
@@ -266,7 +290,15 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [],
+            "filter": Array [
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
+            ],
             "must": Array [],
             "must_not": Array [],
           },
@@ -321,7 +353,15 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [],
+            "filter": Array [
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
+            ],
             "must": Array [],
             "must_not": Array [],
           },
@@ -344,7 +384,15 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [],
+            "filter": Array [
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
+            ],
             "must": Array [],
             "must_not": Array [],
           },
@@ -428,7 +476,15 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [],
+            "filter": Array [
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
+            ],
             "must": Array [],
             "must_not": Array [],
           },
@@ -805,7 +861,15 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [],
+            "filter": Array [
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
+            ],
             "must": Array [],
             "must_not": Array [],
           },
@@ -860,7 +924,15 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [],
+            "filter": Array [
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
+            ],
             "must": Array [],
             "must_not": Array [],
           },
@@ -883,7 +955,15 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [],
+            "filter": Array [
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
+            ],
             "must": Array [],
             "must_not": Array [],
           },
@@ -938,7 +1018,15 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [],
+            "filter": Array [
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
+            ],
             "must": Array [],
             "must_not": Array [],
           },
@@ -993,7 +1081,15 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [],
+            "filter": Array [
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
+            ],
             "must": Array [],
             "must_not": Array [],
           },
@@ -1071,7 +1167,15 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [],
+            "filter": Array [
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
+            ],
             "must": Array [],
             "must_not": Array [],
           },
@@ -1085,77 +1189,22 @@ Array [
 ]
 `;
 
-exports[`typeSearch _revinclude:iterate: msearch queries 1`] = `
-Array [
-  Array [
-    Object {
-      "body": Array [
-        Object {
-          "index": "medicationadministration",
-        },
-        Object {
-          "query": Object {
-            "bool": Object {
-              "filter": Array [
-                Object {
-                  "terms": Object {
-                    "request.reference.keyword": Array [
-                      "MedicationRequest/medicationrequest-id-111",
-                    ],
-                  },
-                },
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
-                },
-              ],
-            },
-          },
-        },
-      ],
-    },
-  ],
-  Array [
-    Object {
-      "body": Array [
-        Object {
-          "index": "medicationstatement",
-        },
-        Object {
-          "query": Object {
-            "bool": Object {
-              "filter": Array [
-                Object {
-                  "terms": Object {
-                    "partOf.reference.keyword": Array [
-                      "MedicationAdministration/medication-administration-111",
-                    ],
-                  },
-                },
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
-                },
-              ],
-            },
-          },
-        },
-      ],
-    },
-  ],
-]
-`;
-
-exports[`typeSearch _revinclude:iterate: search queries 1`] = `
+exports[`typeSearch _revinclude:iterate 1`] = `
 Array [
   Array [
     Object {
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [],
+            "filter": Array [
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
+            ],
             "must": Array [],
             "must_not": Array [],
           },
@@ -1193,7 +1242,7 @@ Object {
 }
 `;
 
-exports[`typeSearch query snapshots for Date queryParams={"birthDate":"2020-01-12"}: msearch queries 1`] = `
+exports[`typeSearch query snapshots for Date queryParams={"birthDate":"2020-01-12"} 1`] = `
 Array [
   Array [
     Object {
@@ -1201,6 +1250,13 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
               Object {
                 "range": Object {
                   "birthDate": Object {
@@ -1223,7 +1279,7 @@ Array [
 ]
 `;
 
-exports[`typeSearch query snapshots for Date queryParams={"birthDate":"2020-01-12"}: search queries 1`] = `
+exports[`typeSearch query snapshots for Date queryParams={"birthDate":"2020-01-12eq"} 1`] = `
 Array [
   Array [
     Object {
@@ -1231,36 +1287,13 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Object {
-                "range": Object {
-                  "birthDate": Object {
-                    "gte": "2020-01-12",
-                    "lte": "2020-01-12",
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                   },
                 },
-              },
-            ],
-            "must": Array [],
-            "must_not": Array [],
-          },
-        },
-      },
-      "from": 0,
-      "index": "patient",
-      "size": 20,
-    },
-  ],
-]
-`;
-
-exports[`typeSearch query snapshots for Date queryParams={"birthDate":"2020-01-12eq"}: msearch queries 1`] = `
-Array [
-  Array [
-    Object {
-      "body": Object {
-        "query": Object {
-          "bool": Object {
-            "filter": Array [
+              ],
               Object {
                 "range": Object {
                   "birthDate": Object {
@@ -1283,7 +1316,7 @@ Array [
 ]
 `;
 
-exports[`typeSearch query snapshots for Date queryParams={"birthDate":"2020-01-12eq"}: search queries 1`] = `
+exports[`typeSearch query snapshots for Date queryParams={"birthDate":"eq2020-01-12"} 1`] = `
 Array [
   Array [
     Object {
@@ -1291,11 +1324,18 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
               Object {
                 "range": Object {
                   "birthDate": Object {
-                    "gte": "2020-01-12eq",
-                    "lte": "2020-01-12eq",
+                    "gte": "2020-01-12",
+                    "lte": "2020-01-12",
                   },
                 },
               },
@@ -1313,67 +1353,7 @@ Array [
 ]
 `;
 
-exports[`typeSearch query snapshots for Date queryParams={"birthDate":"eq2020-01-12"}: msearch queries 1`] = `
-Array [
-  Array [
-    Object {
-      "body": Object {
-        "query": Object {
-          "bool": Object {
-            "filter": Array [],
-            "must": Array [],
-            "must_not": Array [
-              Object {
-                "range": Object {
-                  "birthDate": Object {
-                    "gte": "2020-01-12",
-                    "lte": "2020-01-12",
-                  },
-                },
-              },
-            ],
-          },
-        },
-      },
-      "from": 0,
-      "index": "patient",
-      "size": 20,
-    },
-  ],
-]
-`;
-
-exports[`typeSearch query snapshots for Date queryParams={"birthDate":"eq2020-01-12"}: search queries 1`] = `
-Array [
-  Array [
-    Object {
-      "body": Object {
-        "query": Object {
-          "bool": Object {
-            "filter": Array [],
-            "must": Array [],
-            "must_not": Array [
-              Object {
-                "range": Object {
-                  "birthDate": Object {
-                    "gte": "2020-01-12",
-                    "lte": "2020-01-12",
-                  },
-                },
-              },
-            ],
-          },
-        },
-      },
-      "from": 0,
-      "index": "patient",
-      "size": 20,
-    },
-  ],
-]
-`;
-
-exports[`typeSearch query snapshots for Date queryParams={"birthDate":"gt2020-01-12"}: msearch queries 1`] = `
+exports[`typeSearch query snapshots for Date queryParams={"birthDate":"gt2020-01-12"} 1`] = `
 Array [
   Array [
     Object {
@@ -1381,6 +1361,13 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
               Object {
                 "range": Object {
                   "birthDate": Object {
@@ -1402,7 +1389,7 @@ Array [
 ]
 `;
 
-exports[`typeSearch query snapshots for Date queryParams={"birthDate":"gt2020-01-12"}: search queries 1`] = `
+exports[`typeSearch query snapshots for Date queryParams={"birthDate":"le2020-01-12"} 1`] = `
 Array [
   Array [
     Object {
@@ -1410,35 +1397,13 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Object {
-                "range": Object {
-                  "birthDate": Object {
-                    "gt": "2020-01-12",
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                   },
                 },
-              },
-            ],
-            "must": Array [],
-            "must_not": Array [],
-          },
-        },
-      },
-      "from": 0,
-      "index": "patient",
-      "size": 20,
-    },
-  ],
-]
-`;
-
-exports[`typeSearch query snapshots for Date queryParams={"birthDate":"le2020-01-12"}: msearch queries 1`] = `
-Array [
-  Array [
-    Object {
-      "body": Object {
-        "query": Object {
-          "bool": Object {
-            "filter": Array [
+              ],
               Object {
                 "range": Object {
                   "birthDate": Object {
@@ -1460,7 +1425,7 @@ Array [
 ]
 `;
 
-exports[`typeSearch query snapshots for Date queryParams={"birthDate":"le2020-01-12"}: search queries 1`] = `
+exports[`typeSearch query snapshots for Date queryParams={"birthDate":"sa2020-01-12"} 1`] = `
 Array [
   Array [
     Object {
@@ -1468,93 +1433,58 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
               Object {
                 "range": Object {
                   "birthDate": Object {
+                    "gte": "2020-01-12",
+                  },
+                },
+              },
+            ],
+            "must": Array [],
+            "must_not": Array [],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient",
+      "size": 20,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch query snapshots for Date queryParams={"gender":"female","name":"Emily","birthDate":"eq2020-01-12"} 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
+              Object {
+                "range": Object {
+                  "birthDate": Object {
+                    "gte": "2020-01-12",
                     "lte": "2020-01-12",
                   },
                 },
               },
             ],
-            "must": Array [],
-            "must_not": Array [],
-          },
-        },
-      },
-      "from": 0,
-      "index": "patient",
-      "size": 20,
-    },
-  ],
-]
-`;
-
-exports[`typeSearch query snapshots for Date queryParams={"birthDate":"sa2020-01-12"}: msearch queries 1`] = `
-Array [
-  Array [
-    Object {
-      "body": Object {
-        "query": Object {
-          "bool": Object {
-            "filter": Array [
-              Object {
-                "range": Object {
-                  "birthDate": Object {
-                    "gte": "2020-01-12",
-                  },
-                },
-              },
-            ],
-            "must": Array [],
-            "must_not": Array [],
-          },
-        },
-      },
-      "from": 0,
-      "index": "patient",
-      "size": 20,
-    },
-  ],
-]
-`;
-
-exports[`typeSearch query snapshots for Date queryParams={"birthDate":"sa2020-01-12"}: search queries 1`] = `
-Array [
-  Array [
-    Object {
-      "body": Object {
-        "query": Object {
-          "bool": Object {
-            "filter": Array [
-              Object {
-                "range": Object {
-                  "birthDate": Object {
-                    "gte": "2020-01-12",
-                  },
-                },
-              },
-            ],
-            "must": Array [],
-            "must_not": Array [],
-          },
-        },
-      },
-      "from": 0,
-      "index": "patient",
-      "size": 20,
-    },
-  ],
-]
-`;
-
-exports[`typeSearch query snapshots for Date queryParams={"gender":"female","name":"Emily","birthDate":"eq2020-01-12"}: msearch queries 1`] = `
-Array [
-  Array [
-    Object {
-      "body": Object {
-        "query": Object {
-          "bool": Object {
-            "filter": Array [],
             "must": Array [
               Object {
                 "query_string": Object {
@@ -1577,67 +1507,7 @@ Array [
                 },
               },
             ],
-            "must_not": Array [
-              Object {
-                "range": Object {
-                  "birthDate": Object {
-                    "gte": "2020-01-12",
-                    "lte": "2020-01-12",
-                  },
-                },
-              },
-            ],
-          },
-        },
-      },
-      "from": 0,
-      "index": "patient",
-      "size": 20,
-    },
-  ],
-]
-`;
-
-exports[`typeSearch query snapshots for Date queryParams={"gender":"female","name":"Emily","birthDate":"eq2020-01-12"}: search queries 1`] = `
-Array [
-  Array [
-    Object {
-      "body": Object {
-        "query": Object {
-          "bool": Object {
-            "filter": Array [],
-            "must": Array [
-              Object {
-                "query_string": Object {
-                  "default_operator": "AND",
-                  "fields": Array [
-                    "gender.*",
-                  ],
-                  "lenient": true,
-                  "query": "female",
-                },
-              },
-              Object {
-                "query_string": Object {
-                  "default_operator": "AND",
-                  "fields": Array [
-                    "name.*",
-                  ],
-                  "lenient": true,
-                  "query": "Emily",
-                },
-              },
-            ],
-            "must_not": Array [
-              Object {
-                "range": Object {
-                  "birthDate": Object {
-                    "gte": "2020-01-12",
-                    "lte": "2020-01-12",
-                  },
-                },
-              },
-            ],
+            "must_not": Array [],
           },
         },
       },
@@ -1656,7 +1526,15 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [],
+            "filter": Array [
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
+            ],
             "must": Array [
               Object {
                 "query_string": Object {
@@ -1708,7 +1586,15 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [],
+            "filter": Array [
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
+            ],
             "must": Array [],
             "must_not": Array [],
           },
@@ -1729,7 +1615,15 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [],
+            "filter": Array [
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
+            ],
             "must": Array [],
             "must_not": Array [],
           },
@@ -1750,7 +1644,15 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [],
+            "filter": Array [
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
+            ],
             "must": Array [
               Object {
                 "query_string": Object {
@@ -1782,7 +1684,15 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [],
+            "filter": Array [
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
+            ],
             "must": Array [
               Object {
                 "query_string": Object {
@@ -1824,7 +1734,15 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [],
+            "filter": Array [
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
+            ],
             "must": Array [
               Object {
                 "query_string": Object {
@@ -1856,7 +1774,15 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [],
+            "filter": Array [
+              Array [
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
+            ],
             "must": Array [],
             "must_not": Array [],
           },

--- a/src/__snapshots__/elasticSearchService.test.ts.snap
+++ b/src/__snapshots__/elasticSearchService.test.ts.snap
@@ -1193,6 +1193,462 @@ Object {
 }
 `;
 
+exports[`typeSearch query snapshots for Date queryParams={"birthDate":"2020-01-12"}: msearch queries 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "range": Object {
+                  "birthDate": Object {
+                    "gte": "2020-01-12",
+                    "lte": "2020-01-12",
+                  },
+                },
+              },
+            ],
+            "must": Array [],
+            "must_not": Array [],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient",
+      "size": 20,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch query snapshots for Date queryParams={"birthDate":"2020-01-12"}: search queries 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "range": Object {
+                  "birthDate": Object {
+                    "gte": "2020-01-12",
+                    "lte": "2020-01-12",
+                  },
+                },
+              },
+            ],
+            "must": Array [],
+            "must_not": Array [],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient",
+      "size": 20,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch query snapshots for Date queryParams={"birthDate":"2020-01-12eq"}: msearch queries 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "range": Object {
+                  "birthDate": Object {
+                    "gte": "2020-01-12eq",
+                    "lte": "2020-01-12eq",
+                  },
+                },
+              },
+            ],
+            "must": Array [],
+            "must_not": Array [],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient",
+      "size": 20,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch query snapshots for Date queryParams={"birthDate":"2020-01-12eq"}: search queries 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "range": Object {
+                  "birthDate": Object {
+                    "gte": "2020-01-12eq",
+                    "lte": "2020-01-12eq",
+                  },
+                },
+              },
+            ],
+            "must": Array [],
+            "must_not": Array [],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient",
+      "size": 20,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch query snapshots for Date queryParams={"birthDate":"eq2020-01-12"}: msearch queries 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [],
+            "must": Array [],
+            "must_not": Array [
+              Object {
+                "range": Object {
+                  "birthDate": Object {
+                    "gte": "2020-01-12",
+                    "lte": "2020-01-12",
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient",
+      "size": 20,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch query snapshots for Date queryParams={"birthDate":"eq2020-01-12"}: search queries 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [],
+            "must": Array [],
+            "must_not": Array [
+              Object {
+                "range": Object {
+                  "birthDate": Object {
+                    "gte": "2020-01-12",
+                    "lte": "2020-01-12",
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient",
+      "size": 20,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch query snapshots for Date queryParams={"birthDate":"gt2020-01-12"}: msearch queries 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "range": Object {
+                  "birthDate": Object {
+                    "gt": "2020-01-12",
+                  },
+                },
+              },
+            ],
+            "must": Array [],
+            "must_not": Array [],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient",
+      "size": 20,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch query snapshots for Date queryParams={"birthDate":"gt2020-01-12"}: search queries 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "range": Object {
+                  "birthDate": Object {
+                    "gt": "2020-01-12",
+                  },
+                },
+              },
+            ],
+            "must": Array [],
+            "must_not": Array [],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient",
+      "size": 20,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch query snapshots for Date queryParams={"birthDate":"le2020-01-12"}: msearch queries 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "range": Object {
+                  "birthDate": Object {
+                    "lte": "2020-01-12",
+                  },
+                },
+              },
+            ],
+            "must": Array [],
+            "must_not": Array [],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient",
+      "size": 20,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch query snapshots for Date queryParams={"birthDate":"le2020-01-12"}: search queries 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "range": Object {
+                  "birthDate": Object {
+                    "lte": "2020-01-12",
+                  },
+                },
+              },
+            ],
+            "must": Array [],
+            "must_not": Array [],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient",
+      "size": 20,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch query snapshots for Date queryParams={"birthDate":"sa2020-01-12"}: msearch queries 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "range": Object {
+                  "birthDate": Object {
+                    "gte": "2020-01-12",
+                  },
+                },
+              },
+            ],
+            "must": Array [],
+            "must_not": Array [],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient",
+      "size": 20,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch query snapshots for Date queryParams={"birthDate":"sa2020-01-12"}: search queries 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "range": Object {
+                  "birthDate": Object {
+                    "gte": "2020-01-12",
+                  },
+                },
+              },
+            ],
+            "must": Array [],
+            "must_not": Array [],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient",
+      "size": 20,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch query snapshots for Date queryParams={"gender":"female","name":"Emily","birthDate":"eq2020-01-12"}: msearch queries 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [],
+            "must": Array [
+              Object {
+                "query_string": Object {
+                  "default_operator": "AND",
+                  "fields": Array [
+                    "gender.*",
+                  ],
+                  "lenient": true,
+                  "query": "female",
+                },
+              },
+              Object {
+                "query_string": Object {
+                  "default_operator": "AND",
+                  "fields": Array [
+                    "name.*",
+                  ],
+                  "lenient": true,
+                  "query": "Emily",
+                },
+              },
+            ],
+            "must_not": Array [
+              Object {
+                "range": Object {
+                  "birthDate": Object {
+                    "gte": "2020-01-12",
+                    "lte": "2020-01-12",
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient",
+      "size": 20,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch query snapshots for Date queryParams={"gender":"female","name":"Emily","birthDate":"eq2020-01-12"}: search queries 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [],
+            "must": Array [
+              Object {
+                "query_string": Object {
+                  "default_operator": "AND",
+                  "fields": Array [
+                    "gender.*",
+                  ],
+                  "lenient": true,
+                  "query": "female",
+                },
+              },
+              Object {
+                "query_string": Object {
+                  "default_operator": "AND",
+                  "fields": Array [
+                    "name.*",
+                  ],
+                  "lenient": true,
+                  "query": "Emily",
+                },
+              },
+            ],
+            "must_not": Array [
+              Object {
+                "range": Object {
+                  "birthDate": Object {
+                    "gte": "2020-01-12",
+                    "lte": "2020-01-12",
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient",
+      "size": 20,
+    },
+  ],
+]
+`;
+
 exports[`typeSearch query snapshots for simple queryParams queryParams={"_count":10,"_getpagesoffset":2,"id":"11111111-1111-1111-1111-111111111111","gender":"female","name":"Emily","_format":"json"} 1`] = `
 Array [
   Array [

--- a/src/__snapshots__/elasticSearchService.test.ts.snap
+++ b/src/__snapshots__/elasticSearchService.test.ts.snap
@@ -111,13 +111,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
             ],
             "must": Array [],
             "must_not": Array [],
@@ -174,13 +172,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
             ],
             "must": Array [],
             "must_not": Array [],
@@ -205,13 +201,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
             ],
             "must": Array [],
             "must_not": Array [],
@@ -291,13 +285,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
             ],
             "must": Array [],
             "must_not": Array [],
@@ -354,13 +346,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
             ],
             "must": Array [],
             "must_not": Array [],
@@ -385,13 +375,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
             ],
             "must": Array [],
             "must_not": Array [],
@@ -477,13 +465,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
             ],
             "must": Array [],
             "must_not": Array [],
@@ -862,13 +848,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
             ],
             "must": Array [],
             "must_not": Array [],
@@ -925,13 +909,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
             ],
             "must": Array [],
             "must_not": Array [],
@@ -956,13 +938,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
             ],
             "must": Array [],
             "must_not": Array [],
@@ -1019,13 +999,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
             ],
             "must": Array [],
             "must_not": Array [],
@@ -1082,13 +1060,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
             ],
             "must": Array [],
             "must_not": Array [],
@@ -1168,13 +1144,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
             ],
             "must": Array [],
             "must_not": Array [],
@@ -1197,13 +1171,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
             ],
             "must": Array [],
             "must_not": Array [],
@@ -1250,13 +1222,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
               Object {
                 "range": Object {
                   "birthDate": Object {
@@ -1287,13 +1257,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
               Object {
                 "range": Object {
                   "birthDate": Object {
@@ -1324,13 +1292,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
               Object {
                 "range": Object {
                   "birthDate": Object {
@@ -1361,13 +1327,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
               Object {
                 "range": Object {
                   "birthDate": Object {
@@ -1397,13 +1361,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
               Object {
                 "range": Object {
                   "birthDate": Object {
@@ -1433,13 +1395,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
               Object {
                 "range": Object {
                   "birthDate": Object {
@@ -1469,13 +1429,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
               Object {
                 "range": Object {
                   "birthDate": Object {
@@ -1527,13 +1485,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
             ],
             "must": Array [
               Object {
@@ -1587,13 +1543,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
             ],
             "must": Array [],
             "must_not": Array [],
@@ -1616,13 +1570,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
             ],
             "must": Array [],
             "must_not": Array [],
@@ -1645,13 +1597,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
             ],
             "must": Array [
               Object {
@@ -1685,13 +1635,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
             ],
             "must": Array [
               Object {
@@ -1735,13 +1683,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
             ],
             "must": Array [
               Object {
@@ -1775,13 +1721,11 @@ Array [
         "query": Object {
           "bool": Object {
             "filter": Array [
-              Array [
-                Object {
-                  "match": Object {
-                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                  },
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
                 },
-              ],
+              },
             ],
             "must": Array [],
             "must_not": Array [],

--- a/src/__snapshots__/elasticSearchService.test.ts.snap
+++ b/src/__snapshots__/elasticSearchService.test.ts.snap
@@ -110,14 +110,9 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
+            "filter": Array [],
             "must": Array [],
+            "must_not": Array [],
           },
         },
       },
@@ -170,14 +165,9 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
+            "filter": Array [],
             "must": Array [],
+            "must_not": Array [],
           },
         },
       },
@@ -198,14 +188,9 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
+            "filter": Array [],
             "must": Array [],
+            "must_not": Array [],
           },
         },
       },
@@ -281,14 +266,9 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
+            "filter": Array [],
             "must": Array [],
+            "must_not": Array [],
           },
         },
       },
@@ -341,14 +321,9 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
+            "filter": Array [],
             "must": Array [],
+            "must_not": Array [],
           },
         },
       },
@@ -369,14 +344,9 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
+            "filter": Array [],
             "must": Array [],
+            "must_not": Array [],
           },
         },
       },
@@ -458,14 +428,9 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
+            "filter": Array [],
             "must": Array [],
+            "must_not": Array [],
           },
         },
       },
@@ -840,14 +805,9 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
+            "filter": Array [],
             "must": Array [],
+            "must_not": Array [],
           },
         },
       },
@@ -900,14 +860,9 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
+            "filter": Array [],
             "must": Array [],
+            "must_not": Array [],
           },
         },
       },
@@ -928,14 +883,9 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
+            "filter": Array [],
             "must": Array [],
+            "must_not": Array [],
           },
         },
       },
@@ -988,14 +938,9 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
+            "filter": Array [],
             "must": Array [],
+            "must_not": Array [],
           },
         },
       },
@@ -1048,14 +993,9 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
+            "filter": Array [],
             "must": Array [],
+            "must_not": Array [],
           },
         },
       },
@@ -1131,14 +1071,9 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
+            "filter": Array [],
             "must": Array [],
+            "must_not": Array [],
           },
         },
       },
@@ -1220,14 +1155,9 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
+            "filter": Array [],
             "must": Array [],
+            "must_not": Array [],
           },
         },
       },
@@ -1270,13 +1200,7 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
+            "filter": Array [],
             "must": Array [
               Object {
                 "query_string": Object {
@@ -1309,6 +1233,7 @@ Array [
                 },
               },
             ],
+            "must_not": Array [],
           },
         },
       },
@@ -1327,14 +1252,9 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
+            "filter": Array [],
             "must": Array [],
+            "must_not": Array [],
           },
         },
       },
@@ -1353,14 +1273,9 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
+            "filter": Array [],
             "must": Array [],
+            "must_not": Array [],
           },
         },
       },
@@ -1379,13 +1294,7 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
+            "filter": Array [],
             "must": Array [
               Object {
                 "query_string": Object {
@@ -1398,6 +1307,7 @@ Array [
                 },
               },
             ],
+            "must_not": Array [],
           },
         },
       },
@@ -1416,13 +1326,7 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
+            "filter": Array [],
             "must": Array [
               Object {
                 "query_string": Object {
@@ -1445,6 +1349,7 @@ Array [
                 },
               },
             ],
+            "must_not": Array [],
           },
         },
       },
@@ -1463,13 +1368,7 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
+            "filter": Array [],
             "must": Array [
               Object {
                 "query_string": Object {
@@ -1482,6 +1381,7 @@ Array [
                 },
               },
             ],
+            "must_not": Array [],
           },
         },
       },
@@ -1500,14 +1400,9 @@ Array [
       "body": Object {
         "query": Object {
           "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
+            "filter": Array [],
             "must": Array [],
+            "must_not": Array [],
           },
         },
       },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,4 +10,54 @@ export const enum SEARCH_PAGINATION_PARAMS {
     COUNT = '_count',
 }
 
+// Add here which requires date based search
+export const DATEFIELDS = [
+    'birthDate',
+    'effectiveDateTime',
+    'date',
+    'dueDate',
+    'occurrenceDateTime',
+    'manufactureDate',
+    'expirationDate',
+    'performedDateTime',
+];
+
 export const SEPARATOR: string = '_';
+
+export const ITERATIVE_INCLUSION_PARAMETERS = ['_include:iterate', '_revinclude:iterate'];
+
+export const NON_SEARCHABLE_PARAMETERS = [
+    SEARCH_PAGINATION_PARAMS.PAGES_OFFSET,
+    SEARCH_PAGINATION_PARAMS.COUNT,
+    '_format',
+    '_include',
+    '_revinclude',
+    ...ITERATIVE_INCLUSION_PARAMETERS,
+];
+
+export const ALLOWED_PREFIXES = ['eq', 'ne', 'gt', 'lt', 'ge', 'le', 'sa', 'eb', 'ap'];
+
+export const enum PREFIXES {
+    EQUAL = 'eq',
+    NOTEQUAL = 'ne',
+    GREATER = 'gt',
+    LESSER = 'lt',
+    GREATEROREQUAL = 'ge',
+    LESSEROREQUAL = 'le',
+    STARTSAFTER = 'sa', // These values need to be set appropriately
+    ENDSBEFORE = 'eb', // These values need to be set appropriately
+    APPROXIMATION = 'ap', // These values need to be set appropriately
+}
+
+export const enum ESOPERATORS {
+    LESSEROREQUAL = 'lte',
+    GREATEROREQUAL = 'gte',
+    GREATER = 'gt',
+    LESSER = 'lt',
+}
+
+export const enum TYPEOFQUERY {
+    FILTER = 'FILTER',
+    MUST = 'MUST',
+    MUST_NOT = 'MUST_NOT',
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,7 +11,7 @@ export const enum SEARCH_PAGINATION_PARAMS {
 }
 
 // Add here which requires date based search
-export const DATEFIELDS = [
+export const DATE_FIELDS = [
     'birthDate',
     'effectiveDateTime',
     'date',
@@ -39,24 +39,24 @@ export const ALLOWED_PREFIXES = ['eq', 'ne', 'gt', 'lt', 'ge', 'le', 'sa', 'eb',
 
 export const enum PREFIXES {
     EQUAL = 'eq',
-    NOTEQUAL = 'ne',
+    NOT_EQUAL = 'ne',
     GREATER = 'gt',
     LESSER = 'lt',
-    GREATEROREQUAL = 'ge',
-    LESSEROREQUAL = 'le',
-    STARTSAFTER = 'sa', // These values need to be set appropriately
-    ENDSBEFORE = 'eb', // These values need to be set appropriately
+    GREATER_OR_EQUAL = 'ge',
+    LESSER_OR_EQUAL = 'le',
+    STARTS_AFTER = 'sa', // These values need to be set appropriately
+    ENDS_BEFORE = 'eb', // These values need to be set appropriately
     APPROXIMATION = 'ap', // These values need to be set appropriately
 }
 
-export const enum ESOPERATORS {
-    LESSEROREQUAL = 'lte',
-    GREATEROREQUAL = 'gte',
+export const enum ES_OPERATORS {
+    LESSER_OR_EQUAL = 'lte',
+    GREATER_OR_EQUAL = 'gte',
     GREATER = 'gt',
     LESSER = 'lt',
 }
 
-export const enum TYPEOFQUERY {
+export const enum TYPE_OF_QUERY {
     FILTER = 'FILTER',
     MUST = 'MUST',
     MUST_NOT = 'MUST_NOT',

--- a/src/elasticSearchService.test.ts
+++ b/src/elasticSearchService.test.ts
@@ -376,9 +376,7 @@ describe('typeSearch', () => {
             queryParams: { ...queryParams },
             allowedResourceTypes: ALLOWED_RESOURCE_TYPES,
         });
-
-        expect((ElasticSearch.search as jest.Mock).mock.calls).toMatchSnapshot('search queries');
-        expect((ElasticSearch.msearch as jest.Mock).mock.calls).toMatchSnapshot('msearch queries');
+        expect((ElasticSearch.search as jest.Mock).mock.calls).toMatchSnapshot();
     });
     describe('query snapshots for Date', () => {
         each([
@@ -423,8 +421,7 @@ describe('typeSearch', () => {
                 queryParams,
                 allowedResourceTypes: ALLOWED_RESOURCE_TYPES,
             });
-            expect((ElasticSearch.search as jest.Mock).mock.calls).toMatchSnapshot('search queries');
-            expect((ElasticSearch.search as jest.Mock).mock.calls).toMatchSnapshot('msearch queries');
+            expect((ElasticSearch.search as jest.Mock).mock.calls).toMatchSnapshot();
         });
     });
 });

--- a/src/elasticSearchService.test.ts
+++ b/src/elasticSearchService.test.ts
@@ -380,4 +380,51 @@ describe('typeSearch', () => {
         expect((ElasticSearch.search as jest.Mock).mock.calls).toMatchSnapshot('search queries');
         expect((ElasticSearch.msearch as jest.Mock).mock.calls).toMatchSnapshot('msearch queries');
     });
+    describe('query snapshots for Date', () => {
+        each([
+            [{ birthDate: '2020-01-12' }],
+            [{ birthDate: 'eq2020-01-12' }],
+            [{ birthDate: 'le2020-01-12' }],
+            [{ birthDate: 'sa2020-01-12' }],
+            [{ birthDate: 'gt2020-01-12' }],
+            [{ gender: 'female', name: 'Emily', birthDate: 'eq2020-01-12' }],
+            [{ birthDate: '2020-01-12eq' }],
+        ]).test('queryParams=%j', async (queryParams: any) => {
+            const fakeSearchResult = {
+                body: {
+                    hits: {
+                        total: {
+                            value: 1,
+                            relation: 'eq',
+                        },
+                        max_score: 1,
+                        hits: [
+                            {
+                                _index: 'patient',
+                                _type: '_doc',
+                                _id: 'ab69afd3-39ed-42c3-9f77-8a718a247742_1',
+                                _score: 1,
+                                _source: {
+                                    vid: '1',
+                                    id: 'ab69afd3-39ed-42c3-9f77-8a718a247742',
+                                    resourceType: 'Patient',
+                                    birthDate: '1987-02-20',
+                                },
+                            },
+                        ],
+                    },
+                },
+            };
+            (ElasticSearch.search as jest.Mock).mockResolvedValue(fakeSearchResult);
+            const es = new ElasticSearchService(FILTER_RULES_FOR_ACTIVE_RESOURCES);
+            await es.typeSearch({
+                resourceType: 'Patient',
+                baseUrl: 'https://base-url.com',
+                queryParams,
+                allowedResourceTypes: ALLOWED_RESOURCE_TYPES,
+            });
+            expect((ElasticSearch.search as jest.Mock).mock.calls).toMatchSnapshot('search queries');
+            expect((ElasticSearch.search as jest.Mock).mock.calls).toMatchSnapshot('msearch queries');
+        });
+    });
 });

--- a/src/elasticSearchService.ts
+++ b/src/elasticSearchService.ts
@@ -67,7 +67,7 @@ export class ElasticSearchService implements Search {
                 ? Number(queryParams[SEARCH_PAGINATION_PARAMS.COUNT])
                 : DEFAULT_SEARCH_RESULTS_PER_PAGE;
             const searchParameterToValue = { ...queryParams };
-            const body: any = buildQuery(searchParameterToValue);
+            const body: any = buildQuery(searchParameterToValue, this.filterRulesForActiveResources);
             const params = {
                 index: resourceType.toLowerCase(),
                 from,

--- a/src/elasticSearchService.ts
+++ b/src/elasticSearchService.ts
@@ -19,7 +19,7 @@ import {
 import { ElasticSearch } from './elasticSearch';
 import { DEFAULT_SEARCH_RESULTS_PER_PAGE, SEARCH_PAGINATION_PARAMS } from './constants';
 import { buildIncludeQueries, buildRevIncludeQueries } from './searchInclusions';
-import { QueryBuilder } from './queryBuilder';
+import { buildQuery } from './queryBuilder';
 
 const ITERATIVE_INCLUSION_PARAMETERS = ['_include:iterate', '_revinclude:iterate'];
 
@@ -67,8 +67,7 @@ export class ElasticSearchService implements Search {
                 ? Number(queryParams[SEARCH_PAGINATION_PARAMS.COUNT])
                 : DEFAULT_SEARCH_RESULTS_PER_PAGE;
             const searchParameterToValue = { ...queryParams };
-            const queryBuilder = new QueryBuilder(searchParameterToValue);
-            const body: any = queryBuilder.buildQuery();
+            const body: any = buildQuery(searchParameterToValue);
             const params = {
                 index: resourceType.toLowerCase(),
                 from,
@@ -76,7 +75,6 @@ export class ElasticSearchService implements Search {
                 body,
             };
 
-            console.log(JSON.stringify(params));
             const { total, hits } = await this.executeQuery(params);
             const result: SearchResult = {
                 numberOfResults: total,

--- a/src/queryBuilder.ts
+++ b/src/queryBuilder.ts
@@ -1,0 +1,142 @@
+/* eslint-disable class-methods-use-this */
+import {
+    DATEFIELDS,
+    NON_SEARCHABLE_PARAMETERS,
+    ALLOWED_PREFIXES,
+    TYPEOFQUERY,
+    PREFIXES,
+    ESOPERATORS,
+} from './constants';
+import { getDocumentField } from './searchParametersMapping';
+
+export interface prefixBasedSearch {
+    prefix?: string;
+    value: string;
+}
+
+export class QueryBuilder {
+    private queryParams: any;
+
+    constructor(queryParams: any) {
+        this.queryParams = queryParams;
+    }
+
+    buildQuery(): any {
+        const must: any[] = [];
+        const filter: any[] = [];
+        const mustNot: any[] = [];
+        Object.entries(this.queryParams).forEach(([searchParameter, value]) => {
+            // ignore search parameters
+            if (NON_SEARCHABLE_PARAMETERS.includes(searchParameter)) {
+                return;
+            }
+            const field = getDocumentField(searchParameter);
+            const { typeOfQuery, query } = this.splitQuery(field, searchParameter, value as string);
+            if (typeOfQuery === TYPEOFQUERY.FILTER) {
+                filter.push(query);
+            } else if (typeOfQuery === TYPEOFQUERY.MUST_NOT) {
+                mustNot.push(query);
+            } else {
+                must.push(query);
+            }
+        });
+
+        return {
+            query: {
+                bool: {
+                    must,
+                    must_not: mustNot,
+                    filter,
+                },
+            },
+        };
+    }
+
+    private formatPrefix(prefix: string): string {
+        if (prefix === PREFIXES.GREATEROREQUAL) {
+            return ESOPERATORS.GREATEROREQUAL;
+        }
+        if (prefix === PREFIXES.LESSEROREQUAL) {
+            return ESOPERATORS.LESSEROREQUAL;
+        }
+        if (prefix === PREFIXES.STARTSAFTER) {
+            return ESOPERATORS.GREATEROREQUAL;
+        }
+        if (prefix === PREFIXES.ENDSBEFORE) {
+            return ESOPERATORS.LESSEROREQUAL;
+        }
+        if (prefix === PREFIXES.ENDSBEFORE) {
+            return ESOPERATORS.LESSEROREQUAL; // need to implement approximation
+        }
+        return prefix;
+    }
+
+    private splitPrefixAndValue(value: string): prefixBasedSearch {
+        // eslint-disable-next-line no-restricted-syntax
+        for (const prefix of ALLOWED_PREFIXES) {
+            if (value.includes(prefix)) {
+                return { prefix: this.formatPrefix(prefix), value: value.split(prefix)[1] };
+            }
+        }
+        return { prefix: undefined, value };
+    }
+
+    private dateBasedSearch(searchParameter: string, searchvalue: string): any {
+        const search = this.splitPrefixAndValue(searchvalue);
+        let query = {};
+
+        // No Prefix is available for dates
+        if (search.prefix === undefined) {
+            query = {
+                range: {
+                    [searchParameter]: {
+                        gte: search.value,
+                        lte: search.value,
+                    },
+                },
+            };
+            return { typeOfQuery: TYPEOFQUERY.FILTER, query };
+        }
+
+        // NOT EQUAL Prefix
+        if (search.prefix === PREFIXES.NOTEQUAL) {
+            query = {
+                range: {
+                    [searchParameter]: {
+                        gte: search.value,
+                        lte: search.value,
+                    },
+                },
+            };
+            return { typeOfQuery: TYPEOFQUERY.MUST_NOT, query };
+        }
+
+        // Need to implement approximations
+
+        // All other prefixes
+        query = {
+            range: {
+                [searchParameter]: {
+                    [search.prefix]: search.value,
+                },
+            },
+        };
+        return { typeOfQuery: TYPEOFQUERY.FILTER, query };
+    }
+
+    // Split the query based on search field data types
+    private splitQuery(field: string, searchParameter: string, value: string) {
+        if (DATEFIELDS.includes(searchParameter)) return this.dateBasedSearch(searchParameter, value);
+        //  Use for all other search parameters.
+        // TODO: Need to refine this search parameter
+        const query = {
+            query_string: {
+                fields: [field],
+                query: value,
+                default_operator: 'AND',
+                lenient: true,
+            },
+        };
+        return { typeOfQuery: TYPEOFQUERY.MUST, query };
+    }
+}

--- a/src/queryBuilder.ts
+++ b/src/queryBuilder.ts
@@ -122,7 +122,7 @@ export function buildQuery(queryParams: any, filterRulesForActiveResources: any)
     const filter: any[] = [];
     const mustNot: any[] = [];
     // Filter based on the user request
-    if (filterRulesForActiveResources.length > 0) filter.push(filterRulesForActiveResources);
+    if (filterRulesForActiveResources.length > 0) filter.push(...filterRulesForActiveResources);
 
     Object.entries(queryParams).forEach(([searchParameter, value]) => {
         // ignore search parameters

--- a/src/queryBuilder.ts
+++ b/src/queryBuilder.ts
@@ -54,7 +54,7 @@ function dateBasedSearch(searchParameter: string, searchvalue: string): any {
     let query = {};
 
     // No Prefix is available for dates
-    if (search.prefix === undefined) {
+    if (search.prefix === undefined || search.prefix === PREFIXES.EQUAL) {
         query = {
             range: {
                 [searchParameter]: {
@@ -67,7 +67,7 @@ function dateBasedSearch(searchParameter: string, searchvalue: string): any {
     }
 
     // NOT EQUAL Prefix
-    if (search.prefix === PREFIXES.NOT_EQUAL || search.prefix === PREFIXES.EQUAL) {
+    if (search.prefix === PREFIXES.NOT_EQUAL) {
         query = {
             range: {
                 [searchParameter]: {
@@ -111,13 +111,19 @@ function splitQuery(field: string, searchParameter: string, value: string) {
 /**
  * @param Pass Query strings  {"parameter1": "prefixvalue1", "parameter2": "prefixvalue2"}
  * ex - {"birthDate": "eq2020-12-01"}
+ * @param filterRulesForActiveResources - If you are storing both History and Search resources
+ * in your elastic search you can filter out your History elements by supplying a filter argument like:
+ * [{ match: { documentStatus: 'AVAILABLE' }}]
  * @param Returns built ES query
  */
 
-export function buildQuery(queryParams: any): any {
+export function buildQuery(queryParams: any, filterRulesForActiveResources: any): any {
     const must: any[] = [];
     const filter: any[] = [];
     const mustNot: any[] = [];
+    // Filter based on the user request
+    if (filterRulesForActiveResources.length > 0) filter.push(filterRulesForActiveResources);
+
     Object.entries(queryParams).forEach(([searchParameter, value]) => {
         // ignore search parameters
         if (NON_SEARCHABLE_PARAMETERS.includes(searchParameter)) {


### PR DESCRIPTION
Issue #, if available:
Description of changes:

These PR adds support to search based on dates and its prefixes 

From the FHIR spec:
https://www.hl7.org/fhir/search.html

A date parameter searches on a date/time or period. As is usual for date/time related functionality, while the concepts are relatively straight-forward, there are a number of subtleties involved in ensuring consistent behavior.

The date parameter format is yyyy-mm-ddThh:mm:ss[Z|(+|-)hh:mm] (the standard XML format).

**Prefixes:**
eq | the value for the parameter in the resource is equal to the provided value | the range of the search value fully contains the range of the target value
-- | -- | --
ne | the value for the parameter in the resource is not equal to the provided value | the range of the search value does not fully contain the range of the target value
gt | the value for the parameter in the resource is greater than the provided value | the range above the search value intersects (i.e. overlaps) with the range of the target value
lt | the value for the parameter in the resource is less than the provided value | the range below the search value intersects (i.e. overlaps) with the range of the target value
ge | the value for the parameter in the resource is greater or equal to the provided value | the range above the search value intersects (i.e. overlaps) with the range of the target value, or the range of the search value fully contains the range of the target value
le | the value for the parameter in the resource is less or equal to the provided value | the range below the search value intersects (i.e. overlaps) with the range of the target value or the range of the search value fully contains the range of the target value
sa | the value for the parameter in the resource starts after the provided value | the range of the search value does not overlap with the range of the target value, and the range above the search value contains the range of the target value
eb | the value for the parameter in the resource ends before the provided value | the range of the search value does overlap not with the range of the target value, and the range below the search value contains the range of the target value


Other changes 
ap - Approximation changes is not yet implemented. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.