### PR TITLE
feat: use compiled search params to build ES queries

### DIFF
--- a/src/FHIRSearchParametersRegistry/index.ts
+++ b/src/FHIRSearchParametersRegistry/index.ts
@@ -1,0 +1,45 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { FhirVersion } from 'fhir-works-on-aws-interface';
+import compiledSearchParamsV4 from '../schema/compiledSearchParameters.4.0.1.json';
+import compiledSearchParamsV3 from '../schema/compiledSearchParameters.3.0.1.json';
+
+export type SearchParam = {
+    type: string;
+    description: string;
+    target?: string[];
+    compiled: { resourceType: string; path: string; condition?: string[] }[];
+};
+export type CompiledSearchParams = {
+    [resourceType: string]: {
+        [name: string]: SearchParam;
+    };
+};
+
+/**
+ * This class is the single authority over the supported FHIR SearchParameters and their definitions
+ */
+// eslint-disable-next-line import/prefer-default-export
+export class FHIRSearchParametersRegistry {
+    private readonly compiledSearchParams: CompiledSearchParams;
+
+    constructor(fhirVersion: FhirVersion) {
+        if (fhirVersion === '4.0.1') {
+            this.compiledSearchParams = compiledSearchParamsV4 as any;
+        } else {
+            this.compiledSearchParams = compiledSearchParamsV3 as any;
+        }
+    }
+
+    /**
+     * Retrieve a search parameter. Returns undefined if the parameter is not found on the registry.
+     * @param resourceType FHIR resource type
+     * @param name search parameter name
+     */
+    getSearchParameter(resourceType: string, name: string): SearchParam | undefined {
+        return this.compiledSearchParams?.[resourceType]?.[name];
+    }
+}

--- a/src/FHIRSearchParametersRegistry/index.ts
+++ b/src/FHIRSearchParametersRegistry/index.ts
@@ -7,8 +7,43 @@ import { FhirVersion } from 'fhir-works-on-aws-interface';
 import compiledSearchParamsV4 from '../schema/compiledSearchParameters.4.0.1.json';
 import compiledSearchParamsV3 from '../schema/compiledSearchParameters.3.0.1.json';
 
+/**
+ * type: SearchParameter type
+ *
+ * description: SearchParameter description
+ *
+ * target: SearchParameter target. Only used for parameters with type reference
+ *
+ * compiled: array of objects that can be used to build ES queries. In most cases there is a single element in the array. Multiple elements in the array have on OR relationship between them
+ *
+ * compiled[].resourceType: FHIR resource type
+ *
+ * compiled[].path: object path to be used as field in queries
+ *
+ * compiled[].condition: a 3 element array with the elements of a condition [field, operator, value]
+ *
+ * @example
+ * {
+ *    "type": "reference",
+ *    "description": "What resource is being referenced",
+ *    "target": [
+ *      "Library",
+ *      "Account",
+ *      "ActivityDefinition",
+ *    ],
+ *    "compiled": [
+ *      {
+ *        "resourceType": "ActivityDefinition",
+ *        "path": "relatedArtifact.resource",
+ *        "condition": ["relatedArtifact.type", "=", "depends-on"]
+ *      },
+ *      {"resourceType": "ActivityDefinition", "path": "library"}
+ *    ]
+ *  }
+ *
+ */
 export type SearchParam = {
-    type: string;
+    type: 'composite' | 'date' | 'number' | 'quantity' | 'reference' | 'special' | 'string' | 'token' | 'uri';
     description: string;
     target?: string[];
     compiled: { resourceType: string; path: string; condition?: string[] }[];
@@ -39,7 +74,7 @@ export class FHIRSearchParametersRegistry {
      * @param resourceType FHIR resource type
      * @param name search parameter name
      */
-    getSearchParameter(resourceType: string, name: string): SearchParam? {
+    getSearchParameter(resourceType: string, name: string): SearchParam | undefined {
         return this.compiledSearchParams?.[resourceType]?.[name];
     }
 }

--- a/src/FHIRSearchParametersRegistry/index.ts
+++ b/src/FHIRSearchParametersRegistry/index.ts
@@ -39,7 +39,7 @@ export class FHIRSearchParametersRegistry {
      * @param resourceType FHIR resource type
      * @param name search parameter name
      */
-    getSearchParameter(resourceType: string, name: string): SearchParam | undefined {
+    getSearchParameter(resourceType: string, name: string): SearchParam? {
         return this.compiledSearchParams?.[resourceType]?.[name];
     }
 }

--- a/src/__snapshots__/elasticSearchService.test.ts.snap
+++ b/src/__snapshots__/elasticSearchService.test.ts.snap
@@ -1263,7 +1263,7 @@ Object {
 }
 `;
 
-exports[`typeSearch query snapshots for simple queryParams queryParams={"_count":10,"_getpagesoffset":2,"id":"11111111-1111-1111-1111-111111111111","gender":"female","name":"Emily","_format":"json"} 1`] = `
+exports[`typeSearch query snapshots for simple queryParams queryParams={"_count":10,"_getpagesoffset":2,"_id":"11111111-1111-1111-1111-111111111111","gender":"female","name":"Emily","_format":"json"} 1`] = `
 Array [
   Array [
     Object {
@@ -1283,6 +1283,7 @@ Array [
                   "default_operator": "AND",
                   "fields": Array [
                     "id",
+                    "id.*",
                   ],
                   "lenient": true,
                   "query": "11111111-1111-1111-1111-111111111111",
@@ -1292,6 +1293,7 @@ Array [
                 "query_string": Object {
                   "default_operator": "AND",
                   "fields": Array [
+                    "gender",
                     "gender.*",
                   ],
                   "lenient": true,
@@ -1302,6 +1304,7 @@ Array [
                 "query_string": Object {
                   "default_operator": "AND",
                   "fields": Array [
+                    "name",
                     "name.*",
                   ],
                   "lenient": true,
@@ -1392,6 +1395,7 @@ Array [
                   "default_operator": "AND",
                   "fields": Array [
                     "id",
+                    "id.*",
                   ],
                   "lenient": true,
                   "query": "11111111-1111-1111-1111-111111111111",
@@ -1428,6 +1432,7 @@ Array [
                 "query_string": Object {
                   "default_operator": "AND",
                   "fields": Array [
+                    "gender",
                     "gender.*",
                   ],
                   "lenient": true,
@@ -1438,47 +1443,11 @@ Array [
                 "query_string": Object {
                   "default_operator": "AND",
                   "fields": Array [
+                    "name",
                     "name.*",
                   ],
                   "lenient": true,
                   "query": "Emily",
-                },
-              },
-            ],
-          },
-        },
-      },
-      "from": 0,
-      "index": "patient",
-      "size": 20,
-    },
-  ],
-]
-`;
-
-exports[`typeSearch query snapshots for simple queryParams queryParams={"id":"11111111-1111-1111-1111-111111111111"} 1`] = `
-Array [
-  Array [
-    Object {
-      "body": Object {
-        "query": Object {
-          "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
-            "must": Array [
-              Object {
-                "query_string": Object {
-                  "default_operator": "AND",
-                  "fields": Array [
-                    "id",
-                  ],
-                  "lenient": true,
-                  "query": "11111111-1111-1111-1111-111111111111",
                 },
               },
             ],
@@ -1513,6 +1482,223 @@ Array [
       },
       "from": 0,
       "index": "patient",
+      "size": 20,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch search parameters with complex expressions queryParams={"depends-on":"something"} 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [
+              Object {
+                "bool": Object {
+                  "must": Array [
+                    Object {
+                      "query_string": Object {
+                        "default_operator": "AND",
+                        "fields": Array [
+                          "relatedArtifact.resource",
+                          "relatedArtifact.resource.*",
+                        ],
+                        "lenient": true,
+                        "query": "something",
+                      },
+                    },
+                    Object {
+                      "query_string": Object {
+                        "fields": Array [
+                          "relatedArtifact.type",
+                          "relatedArtifact.type.*",
+                        ],
+                        "lenient": true,
+                        "query": "depends-on",
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+      "from": 0,
+      "index": "library",
+      "size": 20,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch search parameters with complex expressions queryParams={"phone":"1234567"} 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [
+              Object {
+                "bool": Object {
+                  "must": Array [
+                    Object {
+                      "query_string": Object {
+                        "default_operator": "AND",
+                        "fields": Array [
+                          "telecom",
+                          "telecom.*",
+                        ],
+                        "lenient": true,
+                        "query": "1234567",
+                      },
+                    },
+                    Object {
+                      "query_string": Object {
+                        "fields": Array [
+                          "telecom.system",
+                          "telecom.system.*",
+                        ],
+                        "lenient": true,
+                        "query": "phone",
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient",
+      "size": 20,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch search parameters with complex expressions queryParams={"relatedperson":"RelatedPerson/111"} 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [
+              Object {
+                "bool": Object {
+                  "must": Array [
+                    Object {
+                      "query_string": Object {
+                        "default_operator": "AND",
+                        "fields": Array [
+                          "link.target",
+                          "link.target.*",
+                        ],
+                        "lenient": true,
+                        "query": "RelatedPerson\\\\/111",
+                      },
+                    },
+                    Object {
+                      "query_string": Object {
+                        "fields": Array [
+                          "link.target",
+                          "link.target.*",
+                        ],
+                        "lenient": true,
+                        "query": "RelatedPerson",
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+      "from": 0,
+      "index": "person",
+      "size": 20,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch search parameters with complex expressions queryParams={"value-string":"some value"} 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [
+              Object {
+                "bool": Object {
+                  "should": Array [
+                    Object {
+                      "query_string": Object {
+                        "default_operator": "AND",
+                        "fields": Array [
+                          "valueString",
+                          "valueString.*",
+                        ],
+                        "lenient": true,
+                        "query": "some value",
+                      },
+                    },
+                    Object {
+                      "query_string": Object {
+                        "default_operator": "AND",
+                        "fields": Array [
+                          "valueCodeableConcept.text",
+                          "valueCodeableConcept.text.*",
+                        ],
+                        "lenient": true,
+                        "query": "some value",
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+      "from": 0,
+      "index": "observation",
       "size": 20,
     },
   ],

--- a/src/elasticSearchService.ts
+++ b/src/elasticSearchService.ts
@@ -15,11 +15,12 @@ import {
     GlobalSearchRequest,
     SearchEntry,
     FhirVersion,
+    InvalidSearchParameterError,
 } from 'fhir-works-on-aws-interface';
 import { ElasticSearch } from './elasticSearch';
 import { DEFAULT_SEARCH_RESULTS_PER_PAGE, SEARCH_PAGINATION_PARAMS } from './constants';
 import { buildIncludeQueries, buildRevIncludeQueries } from './searchInclusions';
-import { getDocumentField } from './searchParametersMapping';
+import { FHIRSearchParametersRegistry } from './FHIRSearchParametersRegistry';
 
 const ITERATIVE_INCLUSION_PARAMETERS = ['_include:iterate', '_revinclude:iterate'];
 
@@ -34,6 +35,10 @@ const NON_SEARCHABLE_PARAMETERS = [
 
 const MAX_INCLUDE_ITERATIVE_DEPTH = 5;
 
+const escapeQueryString = (string: string) => {
+    return string.replace(/\//g, '\\/');
+};
+
 // eslint-disable-next-line import/prefer-default-export
 export class ElasticSearchService implements Search {
     private readonly filterRulesForActiveResources: any[];
@@ -41,6 +46,8 @@ export class ElasticSearchService implements Search {
     private readonly cleanUpFunction: (resource: any) => any;
 
     private readonly fhirVersion: FhirVersion;
+
+    private readonly fhirSearchParams: FHIRSearchParametersRegistry;
 
     /**
      * @param filterRulesForActiveResources - If you are storing both History and Search resources
@@ -60,6 +67,7 @@ export class ElasticSearchService implements Search {
         this.filterRulesForActiveResources = filterRulesForActiveResources;
         this.cleanUpFunction = cleanUpFunction;
         this.fhirVersion = fhirVersion;
+        this.fhirSearchParams = new FHIRSearchParametersRegistry(fhirVersion);
     }
 
     /*
@@ -81,20 +89,63 @@ export class ElasticSearchService implements Search {
 
             const must: any = [];
             // TODO Implement fuzzy matches
-            Object.entries(searchParameterToValue).forEach(([searchParameter, value]) => {
+            Object.entries(searchParameterToValue).forEach(([searchParameter, searchValue]) => {
                 if (NON_SEARCHABLE_PARAMETERS.includes(searchParameter)) {
                     return;
                 }
-                const field = getDocumentField(searchParameter);
-                const query = {
-                    query_string: {
-                        fields: [field],
-                        query: value,
-                        default_operator: 'AND',
-                        lenient: true,
-                    },
-                };
-                must.push(query);
+                const value = escapeQueryString(searchValue as string);
+                const fhirSearchParam = this.fhirSearchParams.getSearchParameter(resourceType, searchParameter);
+                if (fhirSearchParam === undefined) {
+                    throw new InvalidSearchParameterError(
+                        `Invalid search parameter '${searchParameter}' for resource type ${resourceType}`,
+                    );
+                }
+
+                const queries = fhirSearchParam.compiled.map(compiled => {
+                    const fields = [compiled.path, `${compiled.path}.*`];
+
+                    const pathQuery = {
+                        query_string: {
+                            fields,
+                            query: value,
+                            default_operator: 'AND',
+                            lenient: true,
+                        },
+                    };
+
+                    // In most cases conditions are used for fields that are an array of objects
+                    // Ideally we should be using a nested query, but that'd require to update the index mappings.
+                    //
+                    // Simply using an array of bool.must is good enough for most cases. The result will contain the correct documents, however it MAY contain additional documents
+                    // https://www.elastic.co/guide/en/elasticsearch/reference/current/nested.html
+                    if (compiled.condition !== undefined) {
+                        return {
+                            bool: {
+                                must: [
+                                    pathQuery,
+                                    {
+                                        query_string: {
+                                            fields: [compiled.condition[0], `${compiled.condition[0]}.*`],
+                                            query: compiled.condition[2],
+                                            lenient: true,
+                                        },
+                                    },
+                                ],
+                            },
+                        };
+                    }
+                    return pathQuery;
+                });
+
+                if (queries.length === 1) {
+                    must.push(queries[0]);
+                } else {
+                    must.push({
+                        bool: {
+                            should: queries,
+                        },
+                    });
+                }
             });
 
             const filter = this.filterRulesForActiveResources;


### PR DESCRIPTION
Description of changes:

Use the compiled search parameters to build ES queries. 

The basic idea is to:
1. lookup the compiled search parameter
1.2 Throw an error if the param is invalid
2. build the ES query using the path from the compiled FHIR search parameter (instead of the raw parameter as before) 
3. Optionally, add additional query clauses if the compiled FHIR search parameter has conditions

Note: The current implementation does not support the specifics for the different search param types (date, token, etc.). It just treats everything as string. This PR does not change that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.