### PR TITLE
fix: update SearchFilter logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@elastic/elasticsearch": "7",
     "aws-elasticsearch-connector": "^8.2.0",
     "aws-sdk": "^2.610.0",
-    "fhir-works-on-aws-interface": "^7.0.0",
+    "fhir-works-on-aws-interface": "^7.0.1",
     "lodash": "^4.17.20",
     "nearley": "^2.20.0"
   },

--- a/src/__snapshots__/elasticSearchService.test.ts.snap
+++ b/src/__snapshots__/elasticSearchService.test.ts.snap
@@ -1043,7 +1043,7 @@ Array [
             "filter": Array [
               Object {
                 "bool": Object {
-                  "filter": Array [
+                  "should": Array [
                     Object {
                       "match": Object {
                         "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
@@ -1277,7 +1277,133 @@ Array [
 ]
 `;
 
-exports[`typeSearch query snapshots for simple queryParams queryParams={"_count":10,"_getpagesoffset":2,"_id":"11111111-1111-1111-1111-111111111111","gender":"female","name":"Emily","_format":"json"} 1`] = `
+exports[`typeSearch query snapshots for no queryParams, ACTIVE filter & changing filters filterParams=[] 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient",
+      "size": 20,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch query snapshots for no queryParams, ACTIVE filter & changing filters filterParams=[{"key":"_reference","logicalOperator":"OR","comparisonOperator":"==","value":["https://gdieqbxycl.execute-api.us-west-2.amazonaws.com/dev/Patient/3bdd8948-5e3b-4411-8f3f-d352a82bb07d","Patient/3bdd8948-5e3b-4411-8f3f-d352a82bb07d"]}] 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+              Object {
+                "bool": Object {
+                  "should": Array [
+                    Object {
+                      "match": Object {
+                        "_reference": "https://gdieqbxycl.execute-api.us-west-2.amazonaws.com/dev/Patient/3bdd8948-5e3b-4411-8f3f-d352a82bb07d",
+                      },
+                    },
+                    Object {
+                      "match": Object {
+                        "_reference": "Patient/3bdd8948-5e3b-4411-8f3f-d352a82bb07d",
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+            "must": Array [],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient",
+      "size": 20,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch query snapshots for no queryParams, ACTIVE filter & changing filters filterParams=[{"key":"_reference","logicalOperator":"OR","comparisonOperator":"==","value":["https://gdieqbxycl.execute-api.us-west-2.amazonaws.com/dev/Patient/3bdd8948-5e3b-4411-8f3f-d352a82bb07d"]},{"key":"id","logicalOperator":"OR","comparisonOperator":"==","value":["3bdd8948-5e3b-4411-8f3f-d352a82bb07d"]},{"key":"gender","logicalOperator":"AND","comparisonOperator":"==","value":["male","female"]}] 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+              Object {
+                "bool": Object {
+                  "should": Array [
+                    Object {
+                      "match": Object {
+                        "gender": "male",
+                      },
+                    },
+                    Object {
+                      "match": Object {
+                        "gender": "female",
+                      },
+                    },
+                  ],
+                },
+              },
+              Object {
+                "bool": Object {
+                  "should": Array [
+                    Object {
+                      "match": Object {
+                        "_reference": "https://gdieqbxycl.execute-api.us-west-2.amazonaws.com/dev/Patient/3bdd8948-5e3b-4411-8f3f-d352a82bb07d",
+                      },
+                    },
+                    Object {
+                      "match": Object {
+                        "id": "3bdd8948-5e3b-4411-8f3f-d352a82bb07d",
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+            "must": Array [],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient",
+      "size": 20,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch query snapshots for simple queryParams; with ACTIVE filter queryParams={"_count":10,"_getpagesoffset":2,"_id":"11111111-1111-1111-1111-111111111111","gender":"female","name":"Emily","_format":"json"} 1`] = `
 Array [
   Array [
     Object {
@@ -1337,7 +1463,7 @@ Array [
 ]
 `;
 
-exports[`typeSearch query snapshots for simple queryParams queryParams={"_count":10,"_getpagesoffset":2} 1`] = `
+exports[`typeSearch query snapshots for simple queryParams; with ACTIVE filter queryParams={"_count":10,"_getpagesoffset":2} 1`] = `
 Array [
   Array [
     Object {
@@ -1363,7 +1489,7 @@ Array [
 ]
 `;
 
-exports[`typeSearch query snapshots for simple queryParams queryParams={"_format":"json"} 1`] = `
+exports[`typeSearch query snapshots for simple queryParams; with ACTIVE filter queryParams={"_format":"json"} 1`] = `
 Array [
   Array [
     Object {
@@ -1389,7 +1515,7 @@ Array [
 ]
 `;
 
-exports[`typeSearch query snapshots for simple queryParams queryParams={"_id":"11111111-1111-1111-1111-111111111111"} 1`] = `
+exports[`typeSearch query snapshots for simple queryParams; with ACTIVE filter queryParams={"_id":"11111111-1111-1111-1111-111111111111"} 1`] = `
 Array [
   Array [
     Object {
@@ -1427,7 +1553,7 @@ Array [
 ]
 `;
 
-exports[`typeSearch query snapshots for simple queryParams queryParams={"gender":"female","name":"Emily"} 1`] = `
+exports[`typeSearch query snapshots for simple queryParams; with ACTIVE filter queryParams={"gender":"female","name":"Emily"} 1`] = `
 Array [
   Array [
     Object {
@@ -1476,7 +1602,7 @@ Array [
 ]
 `;
 
-exports[`typeSearch query snapshots for simple queryParams queryParams={} 1`] = `
+exports[`typeSearch query snapshots for simple queryParams; with ACTIVE filter queryParams={} 1`] = `
 Array [
   Array [
     Object {
@@ -1490,6 +1616,80 @@ Array [
                 },
               },
             ],
+            "must": Array [],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient",
+      "size": 20,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch query snapshots for simple queryParams; without ACTIVE filter queryParams={"_count":10,"_getpagesoffset":2,"_id":"11111111-1111-1111-1111-111111111111","gender":"female","name":"Emily","_format":"json"} 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [],
+            "must": Array [
+              Object {
+                "query_string": Object {
+                  "default_operator": "AND",
+                  "fields": Array [
+                    "id",
+                    "id.*",
+                  ],
+                  "lenient": true,
+                  "query": "11111111-1111-1111-1111-111111111111",
+                },
+              },
+              Object {
+                "query_string": Object {
+                  "default_operator": "AND",
+                  "fields": Array [
+                    "gender",
+                    "gender.*",
+                  ],
+                  "lenient": true,
+                  "query": "female",
+                },
+              },
+              Object {
+                "query_string": Object {
+                  "default_operator": "AND",
+                  "fields": Array [
+                    "name",
+                    "name.*",
+                  ],
+                  "lenient": true,
+                  "query": "Emily",
+                },
+              },
+            ],
+          },
+        },
+      },
+      "from": 2,
+      "index": "patient",
+      "size": 10,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch query snapshots for simple queryParams; without ACTIVE filter queryParams={} 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [],
             "must": Array [],
           },
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1895,10 +1895,10 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fhir-works-on-aws-interface@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-7.0.0.tgz#2cd4ffb20b42dc3d4ec9a98d90437052841ec6d6"
-  integrity sha512-drZNzZ1zdRgGxOQFdGrEAHJwt77MnyrUw6jQCO9yoX7WBhdLOP0+K1E/4GTnn+AulB7/IJa9bPAKHm5PpybB7Q==
+fhir-works-on-aws-interface@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-7.0.1.tgz#f5fd41ae218d77c6bdc54452c3102a4990c5e4bc"
+  integrity sha512-Ax3yBruz5eeVaBxtEuLQQYdqEIDfqK6nfAT2iWUG7Ky9Warja/3Y4tAIYdiBhYaQ4anFQgz9nyYFQTQUH0JyLQ==
 
 figures@^3.0.0:
   version "3.2.0"


### PR DESCRIPTION
Description of changes:
- Changing the SearchFilter[] -> filter params a bit. 
  - All OR filters will be bundled into a `bool: { should: [ ... ] }`
  - All AND filters will be at the top level of the filter
    - If an AND filter has many values, it will become a separate OR clause that must be there

Query will look something like this:
```json
{
  "filter":[
    { // AND single value
      "match":{
        "documentStatus":"AVAILABLE"
      }
    },
    { // AND with many values
      "bool":{
        "should":[
          {
            "match":{
              "gender":"male"
            }
          },
          {
            "match":{
              "gender":"female"
            }
          }
        ]
      }
    },
    { // ORs
      "bool":{
        "should":[
          {
            "match":{
              "_references":"https://gdieqbxycl.execute-api.us-west-2.amazonaws.com/dev/Patient/e8e511a9-1f57-49b8-91bc-419ede0ba327"
            }
          },
          {
            "match":{
              "_references":"Patient/e8e511a9-1f57-49b8-91bc-419ede0ba327"
            }
          },
          {
            "match":{
              "id":"3bdd8948-5e3b-4411-8f3f-d352a82bb07d"
            }
          }
        ]
      }
    }
  ]
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.