### PR TITLE
fix: properly handle special characters in queries

### DIFF
--- a/src/__snapshots__/elasticSearchService.test.ts.snap
+++ b/src/__snapshots__/elasticSearchService.test.ts.snap
@@ -1419,8 +1419,7 @@ Array [
             ],
             "must": Array [
               Object {
-                "query_string": Object {
-                  "default_operator": "AND",
+                "multi_match": Object {
                   "fields": Array [
                     "id",
                     "id.*",
@@ -1430,8 +1429,7 @@ Array [
                 },
               },
               Object {
-                "query_string": Object {
-                  "default_operator": "AND",
+                "multi_match": Object {
                   "fields": Array [
                     "gender",
                     "gender.*",
@@ -1441,8 +1439,7 @@ Array [
                 },
               },
               Object {
-                "query_string": Object {
-                  "default_operator": "AND",
+                "multi_match": Object {
                   "fields": Array [
                     "name",
                     "name.*",
@@ -1531,8 +1528,7 @@ Array [
             ],
             "must": Array [
               Object {
-                "query_string": Object {
-                  "default_operator": "AND",
+                "multi_match": Object {
                   "fields": Array [
                     "id",
                     "id.*",
@@ -1569,8 +1565,7 @@ Array [
             ],
             "must": Array [
               Object {
-                "query_string": Object {
-                  "default_operator": "AND",
+                "multi_match": Object {
                   "fields": Array [
                     "gender",
                     "gender.*",
@@ -1580,8 +1575,7 @@ Array [
                 },
               },
               Object {
-                "query_string": Object {
-                  "default_operator": "AND",
+                "multi_match": Object {
                   "fields": Array [
                     "name",
                     "name.*",
@@ -1638,8 +1632,7 @@ Array [
             "filter": Array [],
             "must": Array [
               Object {
-                "query_string": Object {
-                  "default_operator": "AND",
+                "multi_match": Object {
                   "fields": Array [
                     "id",
                     "id.*",
@@ -1649,8 +1642,7 @@ Array [
                 },
               },
               Object {
-                "query_string": Object {
-                  "default_operator": "AND",
+                "multi_match": Object {
                   "fields": Array [
                     "gender",
                     "gender.*",
@@ -1660,8 +1652,7 @@ Array [
                 },
               },
               Object {
-                "query_string": Object {
-                  "default_operator": "AND",
+                "multi_match": Object {
                   "fields": Array [
                     "name",
                     "name.*",
@@ -1721,8 +1712,7 @@ Array [
                 "bool": Object {
                   "must": Array [
                     Object {
-                      "query_string": Object {
-                        "default_operator": "AND",
+                      "multi_match": Object {
                         "fields": Array [
                           "relatedArtifact.resource",
                           "relatedArtifact.resource.*",
@@ -1732,7 +1722,7 @@ Array [
                       },
                     },
                     Object {
-                      "query_string": Object {
+                      "multi_match": Object {
                         "fields": Array [
                           "relatedArtifact.type",
                           "relatedArtifact.type.*",
@@ -1775,8 +1765,7 @@ Array [
                 "bool": Object {
                   "must": Array [
                     Object {
-                      "query_string": Object {
-                        "default_operator": "AND",
+                      "multi_match": Object {
                         "fields": Array [
                           "telecom",
                           "telecom.*",
@@ -1786,7 +1775,7 @@ Array [
                       },
                     },
                     Object {
-                      "query_string": Object {
+                      "multi_match": Object {
                         "fields": Array [
                           "telecom.system",
                           "telecom.system.*",
@@ -1829,8 +1818,7 @@ Array [
                 "bool": Object {
                   "must": Array [
                     Object {
-                      "query_string": Object {
-                        "default_operator": "AND",
+                      "multi_match": Object {
                         "fields": Array [
                           "link.target",
                           "link.target.*",
@@ -1840,7 +1828,7 @@ Array [
                       },
                     },
                     Object {
-                      "query_string": Object {
+                      "multi_match": Object {
                         "fields": Array [
                           "link.target",
                           "link.target.*",
@@ -1883,8 +1871,7 @@ Array [
                 "bool": Object {
                   "should": Array [
                     Object {
-                      "query_string": Object {
-                        "default_operator": "AND",
+                      "multi_match": Object {
                         "fields": Array [
                           "valueString",
                           "valueString.*",
@@ -1894,8 +1881,7 @@ Array [
                       },
                     },
                     Object {
-                      "query_string": Object {
-                        "default_operator": "AND",
+                      "multi_match": Object {
                         "fields": Array [
                           "valueCodeableConcept.text",
                           "valueCodeableConcept.text.*",

--- a/src/elasticSearchService.ts
+++ b/src/elasticSearchService.ts
@@ -114,10 +114,9 @@ export class ElasticSearchService implements Search {
                     const fields = [compiled.path, `${compiled.path}.*`];
 
                     const pathQuery = {
-                        query_string: {
+                        multi_match: {
                             fields,
                             query: value,
-                            default_operator: 'AND',
                             lenient: true,
                         },
                     };
@@ -133,7 +132,7 @@ export class ElasticSearchService implements Search {
                                 must: [
                                     pathQuery,
                                     {
-                                        query_string: {
+                                        multi_match: {
                                             fields: [compiled.condition[0], `${compiled.condition[0]}.*`],
                                             query: compiled.condition[2],
                                             lenient: true,


### PR DESCRIPTION
Description of changes:
Fixes part of https://github.com/awslabs/fhir-works-on-aws-deployment/issues/191
For `query_string` queries the following are reserved characters: `+ - = && || > < ! ( ) { } [ ] ^ " ~ * ? : \ /`. Not escaping them was causing issues.

Using `query_string` was not a great idea. `query_string` supports advanced syntax on `query` that we are not using at all and it's just causing issues. Right now we are treating all values simply as text so `multi_match` is a simpler query that gets the job done.

https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.