### PR TITLE
refactor: move query building code into QueryBuilder

### DIFF
--- a/src/FHIRSearchParametersRegistry/index.ts
+++ b/src/FHIRSearchParametersRegistry/index.ts
@@ -51,6 +51,9 @@ import compiledSearchParamsV3 from '../schema/compiledSearchParameters.3.0.1.jso
  *  }
  *
  */
+
+export type CompiledSearchParam = { resourceType: string; path: string; condition?: string[] };
+
 export type SearchParam = {
     name: string;
     url: string;
@@ -58,7 +61,7 @@ export type SearchParam = {
     description: string;
     base: string;
     target?: string[];
-    compiled: { resourceType: string; path: string; condition?: string[] }[];
+    compiled: CompiledSearchParam[];
 };
 
 const toCapabilityStatement = (searchParam: SearchParam) => ({

--- a/src/QueryBuilder/index.ts
+++ b/src/QueryBuilder/index.ts
@@ -1,0 +1,101 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { InvalidSearchParameterError, TypeSearchRequest } from 'fhir-works-on-aws-interface';
+import { NON_SEARCHABLE_PARAMETERS } from '../constants';
+import { CompiledSearchParam, FHIRSearchParametersRegistry, SearchParam } from '../FHIRSearchParametersRegistry';
+import { stringQuery } from './typeQueries/stringQuery';
+
+function typeQueryWithConditions(
+    searchParam: SearchParam,
+    compiledSearchParam: CompiledSearchParam,
+    searchValue: string,
+): any {
+    let typeQuery: any;
+    switch (searchParam.type) {
+        case 'string':
+            typeQuery = stringQuery(compiledSearchParam, searchValue);
+            break;
+        case 'composite':
+        case 'date':
+        case 'number':
+        case 'quantity':
+        case 'reference':
+        case 'special':
+        case 'token':
+        case 'uri':
+        default:
+            typeQuery = stringQuery(compiledSearchParam, searchValue);
+    }
+    // In most cases conditions are used for fields that are an array of objects
+    // Ideally we should be using a nested query, but that'd require to update the index mappings.
+    //
+    // Simply using an array of bool.must is good enough for most cases. The result will contain the correct documents, however it MAY contain additional documents
+    // https://www.elastic.co/guide/en/elasticsearch/reference/current/nested.html
+    if (compiledSearchParam.condition !== undefined) {
+        return {
+            bool: {
+                must: [
+                    typeQuery,
+                    {
+                        multi_match: {
+                            fields: [compiledSearchParam.condition[0], `${compiledSearchParam.condition[0]}.*`],
+                            query: compiledSearchParam.condition[2],
+                            lenient: true,
+                        },
+                    },
+                ],
+            },
+        };
+    }
+    return typeQuery;
+}
+
+function searchParamQuery(searchParam: SearchParam, searchValue: string): any {
+    const queries = searchParam.compiled.map(compiled => {
+        return typeQueryWithConditions(searchParam, compiled, searchValue);
+    });
+
+    if (queries.length === 1) {
+        return queries[0];
+    }
+    return {
+        bool: {
+            should: queries,
+        },
+    };
+}
+
+function searchRequestQuery(
+    fhirSearchParametersRegistry: FHIRSearchParametersRegistry,
+    request: TypeSearchRequest,
+): any[] {
+    const { queryParams, resourceType } = request;
+    return Object.entries(queryParams)
+        .filter(([searchParameter]) => !NON_SEARCHABLE_PARAMETERS.includes(searchParameter))
+        .map(([searchParameter, searchValue]) => {
+            const fhirSearchParam = fhirSearchParametersRegistry.getSearchParameter(resourceType, searchParameter);
+            if (fhirSearchParam === undefined) {
+                throw new InvalidSearchParameterError(
+                    `Invalid search parameter '${searchParameter}' for resource type ${resourceType}`,
+                );
+            }
+            return searchParamQuery(fhirSearchParam, searchValue as string);
+        });
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export const buildQueryForAllSearchParameters = (
+    fhirSearchParametersRegistry: FHIRSearchParametersRegistry,
+    request: TypeSearchRequest,
+    additionalFilters: any[] = [],
+): any => {
+    return {
+        bool: {
+            filter: additionalFilters,
+            must: searchRequestQuery(fhirSearchParametersRegistry, request),
+        },
+    };
+};

--- a/src/QueryBuilder/typeQueries/stringQuery.ts
+++ b/src/QueryBuilder/typeQueries/stringQuery.ts
@@ -1,0 +1,22 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CompiledSearchParam } from '../../FHIRSearchParametersRegistry';
+
+const escapeQueryString = (string: string) => {
+    return string.replace(/\//g, '\\/');
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export function stringQuery(compiled: CompiledSearchParam, value: string): any {
+    const fields = [compiled.path, `${compiled.path}.*`];
+    return {
+        multi_match: {
+            fields,
+            query: escapeQueryString(value),
+            lenient: true,
+        },
+    };
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,3 +11,12 @@ export const enum SEARCH_PAGINATION_PARAMS {
 }
 
 export const SEPARATOR: string = '_';
+export const ITERATIVE_INCLUSION_PARAMETERS = ['_include:iterate', '_revinclude:iterate'];
+export const NON_SEARCHABLE_PARAMETERS = [
+    SEARCH_PAGINATION_PARAMS.PAGES_OFFSET,
+    SEARCH_PAGINATION_PARAMS.COUNT,
+    '_format',
+    '_include',
+    '_revinclude',
+    ...ITERATIVE_INCLUSION_PARAMETERS,
+];


### PR DESCRIPTION
No functional changes, just refactoring. All unit tests pass.

The main goal was to extract the query-building logic that is specific for each search parameter type. This will make it easier to add searching for dates later on.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.