### PR TITLE
feat: support prefixes and proper range queries for date parameters

### DIFF
--- a/THIRD-PARTY
+++ b/THIRD-PARTY
@@ -548,6 +548,18 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ******************************
 
+date-fns
+2.19.0 <https://github.com/date-fns/date-fns>
+Copyright (C) 2020 Sasha Koss and Lesha Koss
+
+# License
+
+date-fns is licensed under the [MIT license](http://kossnocorp.mit-license.org).
+Read more about MIT at [TLDRLegal](https://tldrlegal.com/license/mit-license).
+
+
+******************************
+
 debug
 4.1.1 <https://github.com/visionmedia/debug>
 (The MIT License)

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,11 @@
+// set timezone for consistency in snapshot tests that involve dates
+process.env.TZ = 'UTC';
+
+module.exports = {
+    moduleFileExtensions: ['ts', 'js'],
+    coverageReporters: ['text', 'html'],
+    transform: {
+        '\\.(ts)$': 'ts-jest',
+    },
+    testRegex: '.test.(ts|js)$',
+};

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@elastic/elasticsearch": "7",
     "aws-elasticsearch-connector": "^8.2.0",
     "aws-sdk": "^2.610.0",
+    "date-fns": "^2.19.0",
     "fhir-works-on-aws-interface": "^7.1.0",
     "lodash": "^4.17.20",
     "nearley": "^2.20.0"
@@ -54,20 +55,6 @@
     "prettier": "^1.19.1",
     "ts-jest": "^26.4.4",
     "typescript": "^4.1.3"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "ts",
-      "js"
-    ],
-    "coverageReporters": [
-      "text",
-      "html"
-    ],
-    "transform": {
-      "\\.(ts)$": "ts-jest"
-    },
-    "testRegex": ".test.(ts|js)$"
   },
   "repository": {
     "type": "git",

--- a/src/QueryBuilder/index.ts
+++ b/src/QueryBuilder/index.ts
@@ -7,6 +7,7 @@ import { InvalidSearchParameterError, TypeSearchRequest } from 'fhir-works-on-aw
 import { NON_SEARCHABLE_PARAMETERS } from '../constants';
 import { CompiledSearchParam, FHIRSearchParametersRegistry, SearchParam } from '../FHIRSearchParametersRegistry';
 import { stringQuery } from './typeQueries/stringQuery';
+import { dateQuery } from './typeQueries/dateQuery';
 
 function typeQueryWithConditions(
     searchParam: SearchParam,
@@ -18,8 +19,10 @@ function typeQueryWithConditions(
         case 'string':
             typeQuery = stringQuery(compiledSearchParam, searchValue);
             break;
-        case 'composite':
         case 'date':
+            typeQuery = dateQuery(compiledSearchParam, searchValue);
+            break;
+        case 'composite':
         case 'number':
         case 'quantity':
         case 'reference':

--- a/src/QueryBuilder/typeQueries/dateQuery.test.ts
+++ b/src/QueryBuilder/typeQueries/dateQuery.test.ts
@@ -1,0 +1,225 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+import { InvalidSearchParameterError } from 'fhir-works-on-aws-interface';
+import each from 'jest-each';
+import { dateQuery, parseDateSearchParam } from './dateQuery';
+import { FHIRSearchParametersRegistry } from '../../FHIRSearchParametersRegistry';
+
+const fhirSearchParametersRegistry = new FHIRSearchParametersRegistry('4.0.1');
+const birthdateParam = fhirSearchParametersRegistry.getSearchParameter('Patient', 'birthdate')!.compiled[0];
+
+describe('parseDateSearchParam', () => {
+    describe('valid inputs', () => {
+        test('YYYY', () => {
+            expect(parseDateSearchParam('2020')).toMatchInlineSnapshot(`
+                            Object {
+                              "prefix": "eq",
+                              "range": Object {
+                                "end": 2020-12-31T23:59:59.000Z,
+                                "start": 2020-01-01T00:00:00.000Z,
+                              },
+                            }
+                    `);
+        });
+        test('YYYY-MM', () => {
+            expect(parseDateSearchParam('2020-02')).toMatchInlineSnapshot(`
+                            Object {
+                              "prefix": "eq",
+                              "range": Object {
+                                "end": 2020-02-29T23:59:59.000Z,
+                                "start": 2020-02-01T00:00:00.000Z,
+                              },
+                            }
+                    `);
+        });
+        test('YYYY-MM-DD', () => {
+            expect(parseDateSearchParam('2020-02-02')).toMatchInlineSnapshot(`
+                            Object {
+                              "prefix": "eq",
+                              "range": Object {
+                                "end": 2020-02-02T23:59:59.000Z,
+                                "start": 2020-02-02T00:00:00.000Z,
+                              },
+                            }
+                    `);
+        });
+        test('YYYY-MM-DDT:hh:mm', () => {
+            expect(parseDateSearchParam('2020-02-02T07:07')).toMatchInlineSnapshot(`
+                            Object {
+                              "prefix": "eq",
+                              "range": Object {
+                                "end": 2020-02-02T07:07:59.000Z,
+                                "start": 2020-02-02T07:07:00.000Z,
+                              },
+                            }
+                    `);
+        });
+        test('YYYY-MM-DDT:hh:mm:ss', () => {
+            expect(parseDateSearchParam('2020-02-02T07:07:07')).toMatchInlineSnapshot(`
+                            Object {
+                              "prefix": "eq",
+                              "range": Object {
+                                "end": 2020-02-02T07:07:07.000Z,
+                                "start": 2020-02-02T07:07:07.000Z,
+                              },
+                            }
+                    `);
+        });
+        test('YYYY-MM-DDT:hh:mm:ssZ', () => {
+            expect(parseDateSearchParam('2020-02-02T07:07:07Z')).toMatchInlineSnapshot(`
+                Object {
+                  "prefix": "eq",
+                  "range": Object {
+                    "end": 2020-02-02T07:07:07.000Z,
+                    "start": 2020-02-02T07:07:07.000Z,
+                  },
+                }
+            `);
+        });
+        test('YYYY-MM-DDT:hh:mm:ss+hh:mm', () => {
+            expect(parseDateSearchParam('2020-02-02T07:07:07+07:00')).toMatchInlineSnapshot(`
+                Object {
+                  "prefix": "eq",
+                  "range": Object {
+                    "end": 2020-02-02T00:07:07.000Z,
+                    "start": 2020-02-02T00:07:07.000Z,
+                  },
+                }
+            `);
+        });
+    });
+
+    describe('invalid inputs', () => {
+        each([
+            ['badpre2020-02-02'],
+            ['This is not a date at all'],
+            ['2020-99'],
+            ['2020-99-99'],
+            ['2020/02/02'],
+            ['2020-02-02T07'],
+            ['2020-02-02T07:07:07someSuffix'],
+            ['2020-02-02someSuffix'],
+        ]).test('%s', param => {
+            expect(() => parseDateSearchParam(param)).toThrow(InvalidSearchParameterError);
+        });
+    });
+});
+
+describe('buildDateQuery', () => {
+    test('np prefix', () => {
+        expect(dateQuery(birthdateParam, '1999-09-09')).toMatchInlineSnapshot(`
+            Object {
+              "range": Object {
+                "birthDate": Object {
+                  "gte": 1999-09-09T00:00:00.000Z,
+                  "lte": 1999-09-09T23:59:59.000Z,
+                },
+              },
+            }
+        `);
+    });
+    test('eq', () => {
+        expect(dateQuery(birthdateParam, 'eq1999-09-09')).toMatchInlineSnapshot(`
+            Object {
+              "range": Object {
+                "birthDate": Object {
+                  "gte": 1999-09-09T00:00:00.000Z,
+                  "lte": 1999-09-09T23:59:59.000Z,
+                },
+              },
+            }
+        `);
+    });
+    test('ne', () => {
+        expect(dateQuery(birthdateParam, 'ne1999-09-09')).toMatchInlineSnapshot(`
+            Object {
+              "bool": Object {
+                "should": Array [
+                  Object {
+                    "range": Object {
+                      "birthDate": Object {
+                        "gt": 1999-09-09T23:59:59.000Z,
+                      },
+                    },
+                  },
+                  Object {
+                    "range": Object {
+                      "birthDate": Object {
+                        "lt": 1999-09-09T00:00:00.000Z,
+                      },
+                    },
+                  },
+                ],
+              },
+            }
+        `);
+    });
+    test('lt', () => {
+        expect(dateQuery(birthdateParam, 'lt1999-09-09')).toMatchInlineSnapshot(`
+            Object {
+              "range": Object {
+                "birthDate": Object {
+                  "lt": 1999-09-09T23:59:59.000Z,
+                },
+              },
+            }
+        `);
+    });
+    test('le', () => {
+        expect(dateQuery(birthdateParam, 'le1999-09-09')).toMatchInlineSnapshot(`
+            Object {
+              "range": Object {
+                "birthDate": Object {
+                  "lte": 1999-09-09T23:59:59.000Z,
+                },
+              },
+            }
+        `);
+    });
+    test('gt', () => {
+        expect(dateQuery(birthdateParam, 'gt1999-09-09')).toMatchInlineSnapshot(`
+            Object {
+              "range": Object {
+                "birthDate": Object {
+                  "gt": 1999-09-09T00:00:00.000Z,
+                },
+              },
+            }
+        `);
+    });
+    test('ge', () => {
+        expect(dateQuery(birthdateParam, 'ge1999-09-09')).toMatchInlineSnapshot(`
+            Object {
+              "range": Object {
+                "birthDate": Object {
+                  "gte": 1999-09-09T00:00:00.000Z,
+                },
+              },
+            }
+        `);
+    });
+    test('sa', () => {
+        expect(dateQuery(birthdateParam, 'sa1999-09-09')).toMatchInlineSnapshot(`
+            Object {
+              "range": Object {
+                "birthDate": Object {
+                  "gt": 1999-09-09T23:59:59.000Z,
+                },
+              },
+            }
+        `);
+    });
+    test('eb', () => {
+        expect(dateQuery(birthdateParam, 'eb1999-09-09')).toMatchInlineSnapshot(`
+            Object {
+              "range": Object {
+                "birthDate": Object {
+                  "lt": 1999-09-09T00:00:00.000Z,
+                },
+              },
+            }
+        `);
+    });
+});

--- a/src/QueryBuilder/typeQueries/dateQuery.test.ts
+++ b/src/QueryBuilder/typeQueries/dateQuery.test.ts
@@ -107,8 +107,8 @@ describe('parseDateSearchParam', () => {
     });
 });
 
-describe('buildDateQuery', () => {
-    test('np prefix', () => {
+describe('dateQuery', () => {
+    test('no prefix', () => {
         expect(dateQuery(birthdateParam, '1999-09-09')).toMatchInlineSnapshot(`
             Object {
               "range": Object {

--- a/src/QueryBuilder/typeQueries/dateQuery.ts
+++ b/src/QueryBuilder/typeQueries/dateQuery.ts
@@ -1,0 +1,149 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import parseISO from 'date-fns/parseISO';
+import isValid from 'date-fns/isValid';
+import lastDayOfYear from 'date-fns/lastDayOfYear';
+import lastDayOfMonth from 'date-fns/lastDayOfMonth';
+import set from 'date-fns/set';
+import { InvalidSearchParameterError } from 'fhir-works-on-aws-interface';
+import { CompiledSearchParam } from '../../FHIRSearchParametersRegistry';
+
+interface DateSearchParameter {
+    prefix: string;
+    range: {
+        start: Date;
+        end: Date;
+    };
+}
+
+// The date parameter format is yyyy-mm-ddThh:mm:ss[Z|(+|-)hh:mm] (the standard XML format).
+// https://www.hl7.org/fhir/search.html#date
+const DATE_SEARCH_PARAM_REGEX = /^(?<prefix>eq|ne|lt|gt|ge|le|sa|eb|ap)?(?<inputDate>(?<year>\d{4})(?:-(?<month>\d{2})(?:-(?<day>\d{2})(?:T(?<hours>\d{2}):(?<minutes>\d{2})(?::(?<seconds>\d{2})(?<timeZone>Z|[+-](?:\d{2}:\d{2}))?)?)?)?)?)$/;
+
+export const parseDateSearchParam = (param: string): DateSearchParameter => {
+    const match = param.match(DATE_SEARCH_PARAM_REGEX);
+    if (match === null) {
+        throw new InvalidSearchParameterError(`Invalid date search parameter: ${param}`);
+    }
+    const { inputDate, month, day, minutes, seconds } = match.groups!;
+
+    // If no prefix is present, the prefix eq is assumed.
+    // https://www.hl7.org/fhir/search.html#prefix
+    const prefix = match.groups!.prefix ?? 'eq';
+
+    const parsedDate = parseISO(inputDate);
+    if (!isValid(parsedDate)) {
+        throw new InvalidSearchParameterError(`Invalid date format: ${inputDate}`);
+    }
+
+    // When the date parameter is not fully specified, matches against it are based on the behavior of intervals
+    // https://www.hl7.org/fhir/search.html#date
+    let endDate: Date;
+    const timeEndOfDay = { hours: 23, minutes: 59, seconds: 59 };
+    if (seconds !== undefined) {
+        endDate = parsedDate; // date is fully specified
+    } else if (minutes !== undefined) {
+        endDate = set(parsedDate, { seconds: 59 });
+    } else if (day !== undefined) {
+        endDate = set(parsedDate, timeEndOfDay);
+    } else if (month !== undefined) {
+        endDate = set(lastDayOfMonth(parsedDate), timeEndOfDay);
+    } else {
+        endDate = set(lastDayOfYear(parsedDate), timeEndOfDay);
+    }
+
+    return {
+        prefix,
+        range: {
+            start: parsedDate,
+            end: endDate,
+        },
+    };
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export const dateQuery = (compiledSearchParam: CompiledSearchParam, value: string): any => {
+    const dateSearchParameter = parseDateSearchParam(value);
+    const { start, end } = dateSearchParameter.range;
+
+    // See https://www.hl7.org/fhir/search.html#prefix
+    if (dateSearchParameter.prefix !== 'ne') {
+        let elasticSearchRange;
+        switch (dateSearchParameter.prefix) {
+            case 'eq': // equal
+                elasticSearchRange = {
+                    gte: start,
+                    lte: end,
+                };
+                break;
+            case 'lt': // less than
+                elasticSearchRange = {
+                    lt: end,
+                };
+                break;
+            case 'le': // less or equal
+                elasticSearchRange = {
+                    lte: end,
+                };
+                break;
+            case 'gt': // greater than
+                elasticSearchRange = {
+                    gt: start,
+                };
+                break;
+            case 'ge': // greater or equal
+                elasticSearchRange = {
+                    gte: start,
+                };
+                break;
+            case 'sa': // starts after
+                elasticSearchRange = {
+                    gt: end,
+                };
+                break;
+            case 'eb': // ends before
+                elasticSearchRange = {
+                    lt: start,
+                };
+                break;
+            case 'ap': // approximately
+                throw new InvalidSearchParameterError('Unsupported prefix: ap');
+            default:
+                // this should never happen
+                throw new Error(`unknown search prefix: ${dateSearchParameter.prefix}`);
+        }
+
+        return {
+            range: {
+                [compiledSearchParam.path]: elasticSearchRange,
+            },
+        };
+    }
+
+    // ne prefix is the only case that requires a bool query;
+    const neQuery = {
+        bool: {
+            should: [
+                {
+                    range: {
+                        [compiledSearchParam.path]: {
+                            gt: end,
+                        },
+                    },
+                },
+                {
+                    range: {
+                        [compiledSearchParam.path]: {
+                            lt: start,
+                        },
+                    },
+                },
+            ],
+        },
+    };
+
+    return neQuery;
+};

--- a/src/QueryBuilder/typeQueries/dateQuery.ts
+++ b/src/QueryBuilder/typeQueries/dateQuery.ts
@@ -66,13 +66,13 @@ export const parseDateSearchParam = (param: string): DateSearchParameter => {
 
 // eslint-disable-next-line import/prefer-default-export
 export const dateQuery = (compiledSearchParam: CompiledSearchParam, value: string): any => {
-    const dateSearchParameter = parseDateSearchParam(value);
-    const { start, end } = dateSearchParameter.range;
+    const { prefix, range } = parseDateSearchParam(value);
+    const { start, end } = range;
 
     // See https://www.hl7.org/fhir/search.html#prefix
-    if (dateSearchParameter.prefix !== 'ne') {
+    if (prefix !== 'ne') {
         let elasticSearchRange;
-        switch (dateSearchParameter.prefix) {
+        switch (prefix) {
             case 'eq': // equal
                 elasticSearchRange = {
                     gte: start,
@@ -113,7 +113,7 @@ export const dateQuery = (compiledSearchParam: CompiledSearchParam, value: strin
                 throw new InvalidSearchParameterError('Unsupported prefix: ap');
             default:
                 // this should never happen
-                throw new Error(`unknown search prefix: ${dateSearchParameter.prefix}`);
+                throw new Error(`unknown search prefix: ${prefix}`);
         }
 
         return {

--- a/src/__snapshots__/elasticSearchService.test.ts.snap
+++ b/src/__snapshots__/elasticSearchService.test.ts.snap
@@ -1549,6 +1549,50 @@ Array [
 ]
 `;
 
+exports[`typeSearch query snapshots for simple queryParams; with ACTIVE filter queryParams={"gender":"female","birthdate":"gt1990"} 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [
+              Object {
+                "multi_match": Object {
+                  "fields": Array [
+                    "gender",
+                    "gender.*",
+                  ],
+                  "lenient": true,
+                  "query": "female",
+                },
+              },
+              Object {
+                "range": Object {
+                  "birthDate": Object {
+                    "gt": 1990-01-01T00:00:00.000Z,
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient",
+      "size": 20,
+    },
+  ],
+]
+`;
+
 exports[`typeSearch query snapshots for simple queryParams; with ACTIVE filter queryParams={"gender":"female","name":"Emily"} 1`] = `
 Array [
   Array [

--- a/src/elasticSearchService.test.ts
+++ b/src/elasticSearchService.test.ts
@@ -42,6 +42,7 @@ describe('typeSearch', () => {
             [{}],
             [{ _count: 10, _getpagesoffset: 2 }],
             [{ gender: 'female', name: 'Emily' }],
+            [{ gender: 'female', birthdate: 'gt1990' }],
             [{ _id: '11111111-1111-1111-1111-111111111111' }],
             [{ _format: 'json' }],
             [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1348,6 +1348,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-fns@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.19.0.tgz#65193348635a28d5d916c43ec7ce6fbd145059e1"
+  integrity sha512-X3bf2iTPgCAQp9wvjOQytnf5vO5rESYRXlPIVcgSbtT5OTScPcsf9eZU+B/YIkKAtYr5WeCii58BgATrNitlWg==
+
 debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
Add support for date queries. https://www.hl7.org/fhir/search.html#date

key features are:
- prefixes
https://www.hl7.org/fhir/search.html#prefix
- treat partial dates as ranges
  > When the date parameter is not fully specified, matches against it are based on the behavior of intervals, where:
Dates with only the year specified are equivalent to an interval that starts at the first instant of January 1st to the last instant of December 31st, e.g. 2000 is equivalent to an interval of [2000-01-01T00:00, 2000-12-31T23:59].
...


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.