### PR TITLE
feat: allow milliseconds in date queries

### DIFF
--- a/src/QueryBuilder/typeQueries/dateQuery.test.ts
+++ b/src/QueryBuilder/typeQueries/dateQuery.test.ts
@@ -14,65 +14,76 @@ describe('parseDateSearchParam', () => {
     describe('valid inputs', () => {
         test('YYYY', () => {
             expect(parseDateSearchParam('2020')).toMatchInlineSnapshot(`
-                            Object {
-                              "prefix": "eq",
-                              "range": Object {
-                                "end": 2020-12-31T23:59:59.000Z,
-                                "start": 2020-01-01T00:00:00.000Z,
-                              },
-                            }
-                    `);
+                Object {
+                  "prefix": "eq",
+                  "range": Object {
+                    "end": 2020-12-31T23:59:59.999Z,
+                    "start": 2020-01-01T00:00:00.000Z,
+                  },
+                }
+            `);
         });
         test('YYYY-MM', () => {
             expect(parseDateSearchParam('2020-02')).toMatchInlineSnapshot(`
-                            Object {
-                              "prefix": "eq",
-                              "range": Object {
-                                "end": 2020-02-29T23:59:59.000Z,
-                                "start": 2020-02-01T00:00:00.000Z,
-                              },
-                            }
-                    `);
+                Object {
+                  "prefix": "eq",
+                  "range": Object {
+                    "end": 2020-02-29T23:59:59.999Z,
+                    "start": 2020-02-01T00:00:00.000Z,
+                  },
+                }
+            `);
         });
         test('YYYY-MM-DD', () => {
             expect(parseDateSearchParam('2020-02-02')).toMatchInlineSnapshot(`
-                            Object {
-                              "prefix": "eq",
-                              "range": Object {
-                                "end": 2020-02-02T23:59:59.000Z,
-                                "start": 2020-02-02T00:00:00.000Z,
-                              },
-                            }
-                    `);
+                Object {
+                  "prefix": "eq",
+                  "range": Object {
+                    "end": 2020-02-02T23:59:59.999Z,
+                    "start": 2020-02-02T00:00:00.000Z,
+                  },
+                }
+            `);
         });
         test('YYYY-MM-DDT:hh:mm', () => {
             expect(parseDateSearchParam('2020-02-02T07:07')).toMatchInlineSnapshot(`
-                            Object {
-                              "prefix": "eq",
-                              "range": Object {
-                                "end": 2020-02-02T07:07:59.000Z,
-                                "start": 2020-02-02T07:07:00.000Z,
-                              },
-                            }
-                    `);
+                Object {
+                  "prefix": "eq",
+                  "range": Object {
+                    "end": 2020-02-02T07:07:59.999Z,
+                    "start": 2020-02-02T07:07:00.000Z,
+                  },
+                }
+            `);
         });
         test('YYYY-MM-DDT:hh:mm:ss', () => {
             expect(parseDateSearchParam('2020-02-02T07:07:07')).toMatchInlineSnapshot(`
-                            Object {
-                              "prefix": "eq",
-                              "range": Object {
-                                "end": 2020-02-02T07:07:07.000Z,
-                                "start": 2020-02-02T07:07:07.000Z,
-                              },
-                            }
-                    `);
+                Object {
+                  "prefix": "eq",
+                  "range": Object {
+                    "end": 2020-02-02T07:07:07.999Z,
+                    "start": 2020-02-02T07:07:07.000Z,
+                  },
+                }
+            `);
+        });
+        test('YYYY-MM-DDT:hh:mm:ss.sss', () => {
+            expect(parseDateSearchParam('2020-02-02T07:07:07.777')).toMatchInlineSnapshot(`
+                Object {
+                  "prefix": "eq",
+                  "range": Object {
+                    "end": 2020-02-02T07:07:07.777Z,
+                    "start": 2020-02-02T07:07:07.777Z,
+                  },
+                }
+            `);
         });
         test('YYYY-MM-DDT:hh:mm:ssZ', () => {
             expect(parseDateSearchParam('2020-02-02T07:07:07Z')).toMatchInlineSnapshot(`
                 Object {
                   "prefix": "eq",
                   "range": Object {
-                    "end": 2020-02-02T07:07:07.000Z,
+                    "end": 2020-02-02T07:07:07.999Z,
                     "start": 2020-02-02T07:07:07.000Z,
                   },
                 }
@@ -83,7 +94,7 @@ describe('parseDateSearchParam', () => {
                 Object {
                   "prefix": "eq",
                   "range": Object {
-                    "end": 2020-02-02T00:07:07.000Z,
+                    "end": 2020-02-02T00:07:07.999Z,
                     "start": 2020-02-02T00:07:07.000Z,
                   },
                 }
@@ -114,7 +125,7 @@ describe('dateQuery', () => {
               "range": Object {
                 "birthDate": Object {
                   "gte": 1999-09-09T00:00:00.000Z,
-                  "lte": 1999-09-09T23:59:59.000Z,
+                  "lte": 1999-09-09T23:59:59.999Z,
                 },
               },
             }
@@ -126,7 +137,7 @@ describe('dateQuery', () => {
               "range": Object {
                 "birthDate": Object {
                   "gte": 1999-09-09T00:00:00.000Z,
-                  "lte": 1999-09-09T23:59:59.000Z,
+                  "lte": 1999-09-09T23:59:59.999Z,
                 },
               },
             }
@@ -140,7 +151,7 @@ describe('dateQuery', () => {
                   Object {
                     "range": Object {
                       "birthDate": Object {
-                        "gt": 1999-09-09T23:59:59.000Z,
+                        "gt": 1999-09-09T23:59:59.999Z,
                       },
                     },
                   },
@@ -161,7 +172,7 @@ describe('dateQuery', () => {
             Object {
               "range": Object {
                 "birthDate": Object {
-                  "lt": 1999-09-09T23:59:59.000Z,
+                  "lt": 1999-09-09T23:59:59.999Z,
                 },
               },
             }
@@ -172,7 +183,7 @@ describe('dateQuery', () => {
             Object {
               "range": Object {
                 "birthDate": Object {
-                  "lte": 1999-09-09T23:59:59.000Z,
+                  "lte": 1999-09-09T23:59:59.999Z,
                 },
               },
             }
@@ -205,7 +216,7 @@ describe('dateQuery', () => {
             Object {
               "range": Object {
                 "birthDate": Object {
-                  "gt": 1999-09-09T23:59:59.000Z,
+                  "gt": 1999-09-09T23:59:59.999Z,
                 },
               },
             }

--- a/src/QueryBuilder/typeQueries/dateQuery.ts
+++ b/src/QueryBuilder/typeQueries/dateQuery.ts
@@ -21,14 +21,14 @@ interface DateSearchParameter {
 
 // The date parameter format is yyyy-mm-ddThh:mm:ss[Z|(+|-)hh:mm] (the standard XML format).
 // https://www.hl7.org/fhir/search.html#date
-const DATE_SEARCH_PARAM_REGEX = /^(?<prefix>eq|ne|lt|gt|ge|le|sa|eb|ap)?(?<inputDate>(?<year>\d{4})(?:-(?<month>\d{2})(?:-(?<day>\d{2})(?:T(?<hours>\d{2}):(?<minutes>\d{2})(?::(?<seconds>\d{2})(?<timeZone>Z|[+-](?:\d{2}:\d{2}))?)?)?)?)?)$/;
+const DATE_SEARCH_PARAM_REGEX = /^(?<prefix>eq|ne|lt|gt|ge|le|sa|eb|ap)?(?<inputDate>(?<year>\d{4})(?:-(?<month>\d{2})(?:-(?<day>\d{2})(?:T(?<hours>\d{2}):(?<minutes>\d{2})(?::(?<seconds>\d{2})(?:\.(?<milliseconds>\d{3}))?(?<timeZone>Z|[+-](?:\d{2}:\d{2}))?)?)?)?)?)$/;
 
 export const parseDateSearchParam = (param: string): DateSearchParameter => {
     const match = param.match(DATE_SEARCH_PARAM_REGEX);
     if (match === null) {
         throw new InvalidSearchParameterError(`Invalid date search parameter: ${param}`);
     }
-    const { inputDate, month, day, minutes, seconds } = match.groups!;
+    const { inputDate, month, day, minutes, seconds, milliseconds } = match.groups!;
 
     // If no prefix is present, the prefix eq is assumed.
     // https://www.hl7.org/fhir/search.html#prefix
@@ -42,11 +42,13 @@ export const parseDateSearchParam = (param: string): DateSearchParameter => {
     // When the date parameter is not fully specified, matches against it are based on the behavior of intervals
     // https://www.hl7.org/fhir/search.html#date
     let endDate: Date;
-    const timeEndOfDay = { hours: 23, minutes: 59, seconds: 59 };
-    if (seconds !== undefined) {
+    const timeEndOfDay = { hours: 23, minutes: 59, seconds: 59, milliseconds: 999 };
+    if (milliseconds !== undefined) {
         endDate = parsedDate; // date is fully specified
+    } else if (seconds !== undefined) {
+        endDate = set(parsedDate, { milliseconds: 999 });
     } else if (minutes !== undefined) {
-        endDate = set(parsedDate, { seconds: 59 });
+        endDate = set(parsedDate, { seconds: 59, milliseconds: 999 });
     } else if (day !== undefined) {
         endDate = set(parsedDate, timeEndOfDay);
     } else if (month !== undefined) {


### PR DESCRIPTION
Description of changes:

The FHIR spec does not specifically allow milliseconds but it's nice to support them

https://www.hl7.org/fhir/search.html#date
>  The date parameter format is yyyy-mm-ddThh:mm:ss[Z|(+|-)hh:mm] (the standard XML format). 

milliseconds are very convenient for customers since client applications will lkely use standard Date libraries to generate ISO dates (no milliseconds was a pain when writing our own integ tests). Other FHIR implementations such as HAPI accept milliseconds


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.