### PR TITLE
feat: support token parameters

### DIFF
--- a/src/QueryBuilder/index.ts
+++ b/src/QueryBuilder/index.ts
@@ -8,6 +8,7 @@ import { NON_SEARCHABLE_PARAMETERS } from '../constants';
 import { CompiledSearchParam, FHIRSearchParametersRegistry, SearchParam } from '../FHIRSearchParametersRegistry';
 import { stringQuery } from './typeQueries/stringQuery';
 import { dateQuery } from './typeQueries/dateQuery';
+import { tokenQuery } from './typeQueries/tokenQuery';
 
 function typeQueryWithConditions(
     searchParam: SearchParam,
@@ -22,12 +23,14 @@ function typeQueryWithConditions(
         case 'date':
             typeQuery = dateQuery(compiledSearchParam, searchValue);
             break;
+        case 'token':
+            typeQuery = tokenQuery(compiledSearchParam, searchValue);
+            break;
         case 'composite':
         case 'number':
         case 'quantity':
         case 'reference':
         case 'special':
-        case 'token':
         case 'uri':
         default:
             typeQuery = stringQuery(compiledSearchParam, searchValue);

--- a/src/QueryBuilder/typeQueries/tokenQuery.test.ts
+++ b/src/QueryBuilder/typeQueries/tokenQuery.test.ts
@@ -1,0 +1,186 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { InvalidSearchParameterError } from 'fhir-works-on-aws-interface';
+import { parseTokenSearchParam, tokenQuery } from './tokenQuery';
+import { FHIRSearchParametersRegistry } from '../../FHIRSearchParametersRegistry';
+
+const fhirSearchParametersRegistry = new FHIRSearchParametersRegistry('4.0.1');
+const identifierParam = fhirSearchParametersRegistry.getSearchParameter('Patient', 'identifier')!.compiled[0];
+
+describe('parseTokenSearchParam', () => {
+    describe('valid inputs', () => {
+        test('code', () => {
+            expect(parseTokenSearchParam('code')).toMatchInlineSnapshot(`
+                Object {
+                  "code": "code",
+                  "explicitNoSystemProperty": false,
+                  "system": undefined,
+                }
+            `);
+        });
+        test('system|code', () => {
+            expect(parseTokenSearchParam('system|code')).toMatchInlineSnapshot(`
+                Object {
+                  "code": "code",
+                  "explicitNoSystemProperty": false,
+                  "system": "system",
+                }
+            `);
+        });
+        test('|code', () => {
+            expect(parseTokenSearchParam('|code')).toMatchInlineSnapshot(`
+                Object {
+                  "code": "code",
+                  "explicitNoSystemProperty": true,
+                  "system": undefined,
+                }
+            `);
+        });
+        test('system|', () => {
+            expect(parseTokenSearchParam('system|')).toMatchInlineSnapshot(`
+                Object {
+                  "code": undefined,
+                  "explicitNoSystemProperty": false,
+                  "system": "system",
+                }
+            `);
+        });
+        test('http://acme.org/patient|2345', () => {
+            expect(parseTokenSearchParam('http://acme.org/patient|2345')).toMatchInlineSnapshot(`
+                Object {
+                  "code": "2345",
+                  "explicitNoSystemProperty": false,
+                  "system": "http://acme.org/patient",
+                }
+            `);
+        });
+    });
+
+    describe('invalid inputs', () => {
+        // there are actually very few invalid inputs since almost any string can potentially be a code
+        test('a|b|c', () => {
+            expect(() => parseTokenSearchParam('a|b|c')).toThrow(InvalidSearchParameterError);
+        });
+    });
+});
+
+describe('tokenQuery', () => {
+    test('system|code', () => {
+        expect(tokenQuery(identifierParam, 'http://acme.org/patient|2345')).toMatchInlineSnapshot(`
+            Object {
+              "bool": Object {
+                "must": Array [
+                  Object {
+                    "multi_match": Object {
+                      "fields": Array [
+                        "identifier.system.keyword",
+                        "identifier.coding.system.keyword",
+                      ],
+                      "lenient": true,
+                      "query": "http://acme.org/patient",
+                    },
+                  },
+                  Object {
+                    "multi_match": Object {
+                      "fields": Array [
+                        "identifier.code.keyword",
+                        "identifier.coding.code.keyword",
+                        "identifier.value.keyword",
+                        "identifier.value",
+                        "identifier",
+                      ],
+                      "lenient": true,
+                      "query": "2345",
+                    },
+                  },
+                ],
+              },
+            }
+        `);
+    });
+    test('system|', () => {
+        expect(tokenQuery(identifierParam, 'http://acme.org/patient')).toMatchInlineSnapshot(`
+            Object {
+              "multi_match": Object {
+                "fields": Array [
+                  "identifier.code.keyword",
+                  "identifier.coding.code.keyword",
+                  "identifier.value.keyword",
+                  "identifier.value",
+                  "identifier",
+                ],
+                "lenient": true,
+                "query": "http://acme.org/patient",
+              },
+            }
+        `);
+    });
+    test('|code', () => {
+        expect(tokenQuery(identifierParam, '|2345')).toMatchInlineSnapshot(`
+            Object {
+              "bool": Object {
+                "must": Array [
+                  Object {
+                    "multi_match": Object {
+                      "fields": Array [
+                        "identifier.code.keyword",
+                        "identifier.coding.code.keyword",
+                        "identifier.value.keyword",
+                        "identifier.value",
+                        "identifier",
+                      ],
+                      "lenient": true,
+                      "query": "2345",
+                    },
+                  },
+                  Object {
+                    "bool": Object {
+                      "must_not": Object {
+                        "exists": Object {
+                          "field": "identifier.system",
+                        },
+                      },
+                    },
+                  },
+                ],
+              },
+            }
+        `);
+    });
+    test('code', () => {
+        expect(tokenQuery(identifierParam, 'http://acme.org/patient|2345')).toMatchInlineSnapshot(`
+            Object {
+              "bool": Object {
+                "must": Array [
+                  Object {
+                    "multi_match": Object {
+                      "fields": Array [
+                        "identifier.system.keyword",
+                        "identifier.coding.system.keyword",
+                      ],
+                      "lenient": true,
+                      "query": "http://acme.org/patient",
+                    },
+                  },
+                  Object {
+                    "multi_match": Object {
+                      "fields": Array [
+                        "identifier.code.keyword",
+                        "identifier.coding.code.keyword",
+                        "identifier.value.keyword",
+                        "identifier.value",
+                        "identifier",
+                      ],
+                      "lenient": true,
+                      "query": "2345",
+                    },
+                  },
+                ],
+              },
+            }
+        `);
+    });
+});

--- a/src/QueryBuilder/typeQueries/tokenQuery.test.ts
+++ b/src/QueryBuilder/typeQueries/tokenQuery.test.ts
@@ -57,12 +57,24 @@ describe('parseTokenSearchParam', () => {
                 }
             `);
         });
+        test('empty string', () => {
+            expect(parseTokenSearchParam('')).toMatchInlineSnapshot(`
+                Object {
+                  "code": "",
+                  "explicitNoSystemProperty": false,
+                  "system": undefined,
+                }
+            `);
+        });
     });
 
     describe('invalid inputs', () => {
         // there are actually very few invalid inputs since almost any string can potentially be a code
         test('a|b|c', () => {
             expect(() => parseTokenSearchParam('a|b|c')).toThrow(InvalidSearchParameterError);
+        });
+        test('|', () => {
+            expect(() => parseTokenSearchParam('|')).toThrow(InvalidSearchParameterError);
         });
     });
 });

--- a/src/QueryBuilder/typeQueries/tokenQuery.ts
+++ b/src/QueryBuilder/typeQueries/tokenQuery.ts
@@ -14,6 +14,9 @@ interface TokenSearchParameter {
 
 // eslint-disable-next-line import/prefer-default-export
 export const parseTokenSearchParam = (param: string): TokenSearchParameter => {
+    if (param === '|') {
+        throw new InvalidSearchParameterError(`Invalid token search parameter: ${param}`);
+    }
     const parts = param.split('|');
     if (parts.length > 2) {
         throw new InvalidSearchParameterError(`Invalid token search parameter: ${param}`);
@@ -29,8 +32,10 @@ export const parseTokenSearchParam = (param: string): TokenSearchParameter => {
             system = undefined;
             explicitNoSystemProperty = true;
         }
+        if (code === '') {
+            code = undefined;
+        }
     }
-    code = code === '' ? undefined : code;
     return { system, code, explicitNoSystemProperty };
 };
 

--- a/src/QueryBuilder/typeQueries/tokenQuery.ts
+++ b/src/QueryBuilder/typeQueries/tokenQuery.ts
@@ -1,0 +1,100 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { InvalidSearchParameterError } from 'fhir-works-on-aws-interface';
+import { CompiledSearchParam } from '../../FHIRSearchParametersRegistry';
+
+interface TokenSearchParameter {
+    system?: string;
+    code?: string;
+    explicitNoSystemProperty: boolean;
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export const parseTokenSearchParam = (param: string): TokenSearchParameter => {
+    const parts = param.split('|');
+    if (parts.length > 2) {
+        throw new InvalidSearchParameterError(`Invalid token search parameter: ${param}`);
+    }
+    let system;
+    let code;
+    let explicitNoSystemProperty = false;
+    if (parts.length === 1) {
+        [code] = parts;
+    } else {
+        [system, code] = parts;
+        if (system === '') {
+            system = undefined;
+            explicitNoSystemProperty = true;
+        }
+    }
+    code = code === '' ? undefined : code;
+    return { system, code, explicitNoSystemProperty };
+};
+
+export function tokenQuery(compiled: CompiledSearchParam, value: string): any {
+    const { system, code, explicitNoSystemProperty } = parseTokenSearchParam(value);
+    const queries = [];
+
+    // Token search params are used for many different field types. Search is not aware of the types of the fields in FHIR resources.
+    // The field type is specified in StructureDefinition, but not in SearchParameter.
+    // We are doing a multi_match against all the applicable fields. non-existent fields are simply ignored.
+    // Queries can be simplified if Search gets to know the field types from the StructureDefinitions.
+    // See: https://www.hl7.org/fhir/search.html#token
+    if (system !== undefined) {
+        const fields = [
+            `${compiled.path}.system.keyword`, // Coding, Identifier
+            `${compiled.path}.coding.system.keyword`, // CodeableConcept
+        ];
+
+        queries.push({
+            multi_match: {
+                fields,
+                query: system,
+                lenient: true,
+            },
+        });
+    }
+
+    if (code !== undefined) {
+        const fields = [
+            `${compiled.path}.code.keyword`, // Coding
+            `${compiled.path}.coding.code.keyword`, // CodeableConcept
+            `${compiled.path}.value.keyword`, // Identifier
+            `${compiled.path}.value`, // ContactPoint
+            `${compiled.path}`, // code, boolean, uri, string
+        ];
+
+        queries.push({
+            multi_match: {
+                fields,
+                query: code,
+                lenient: true,
+            },
+        });
+    }
+
+    if (explicitNoSystemProperty) {
+        queries.push({
+            bool: {
+                must_not: {
+                    exists: {
+                        field: `${compiled.path}.system`,
+                    },
+                },
+            },
+        });
+    }
+
+    if (queries.length === 1) {
+        return queries[0];
+    }
+
+    return {
+        bool: {
+            must: queries,
+        },
+    };
+}

--- a/src/__snapshots__/elasticSearchService.test.ts.snap
+++ b/src/__snapshots__/elasticSearchService.test.ts.snap
@@ -1421,8 +1421,11 @@ Array [
               Object {
                 "multi_match": Object {
                   "fields": Array [
+                    "id.code.keyword",
+                    "id.coding.code.keyword",
+                    "id.value.keyword",
+                    "id.value",
                     "id",
-                    "id.*",
                   ],
                   "lenient": true,
                   "query": "11111111-1111-1111-1111-111111111111",
@@ -1431,8 +1434,11 @@ Array [
               Object {
                 "multi_match": Object {
                   "fields": Array [
+                    "gender.code.keyword",
+                    "gender.coding.code.keyword",
+                    "gender.value.keyword",
+                    "gender.value",
                     "gender",
-                    "gender.*",
                   ],
                   "lenient": true,
                   "query": "female",
@@ -1530,8 +1536,11 @@ Array [
               Object {
                 "multi_match": Object {
                   "fields": Array [
+                    "id.code.keyword",
+                    "id.coding.code.keyword",
+                    "id.value.keyword",
+                    "id.value",
                     "id",
-                    "id.*",
                   ],
                   "lenient": true,
                   "query": "11111111-1111-1111-1111-111111111111",
@@ -1567,8 +1576,11 @@ Array [
               Object {
                 "multi_match": Object {
                   "fields": Array [
+                    "gender.code.keyword",
+                    "gender.coding.code.keyword",
+                    "gender.value.keyword",
+                    "gender.value",
                     "gender",
-                    "gender.*",
                   ],
                   "lenient": true,
                   "query": "female",
@@ -1579,6 +1591,75 @@ Array [
                   "birthDate": Object {
                     "gt": 1990-01-01T00:00:00.000Z,
                   },
+                },
+              },
+            ],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient",
+      "size": 20,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch query snapshots for simple queryParams; with ACTIVE filter queryParams={"gender":"female","identifier":"http://acme.org/patient|2345"} 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [
+              Object {
+                "multi_match": Object {
+                  "fields": Array [
+                    "gender.code.keyword",
+                    "gender.coding.code.keyword",
+                    "gender.value.keyword",
+                    "gender.value",
+                    "gender",
+                  ],
+                  "lenient": true,
+                  "query": "female",
+                },
+              },
+              Object {
+                "bool": Object {
+                  "must": Array [
+                    Object {
+                      "multi_match": Object {
+                        "fields": Array [
+                          "identifier.system.keyword",
+                          "identifier.coding.system.keyword",
+                        ],
+                        "lenient": true,
+                        "query": "http://acme.org/patient",
+                      },
+                    },
+                    Object {
+                      "multi_match": Object {
+                        "fields": Array [
+                          "identifier.code.keyword",
+                          "identifier.coding.code.keyword",
+                          "identifier.value.keyword",
+                          "identifier.value",
+                          "identifier",
+                        ],
+                        "lenient": true,
+                        "query": "2345",
+                      },
+                    },
+                  ],
                 },
               },
             ],
@@ -1611,8 +1692,11 @@ Array [
               Object {
                 "multi_match": Object {
                   "fields": Array [
+                    "gender.code.keyword",
+                    "gender.coding.code.keyword",
+                    "gender.value.keyword",
+                    "gender.value",
                     "gender",
-                    "gender.*",
                   ],
                   "lenient": true,
                   "query": "female",
@@ -1678,8 +1762,11 @@ Array [
               Object {
                 "multi_match": Object {
                   "fields": Array [
+                    "id.code.keyword",
+                    "id.coding.code.keyword",
+                    "id.value.keyword",
+                    "id.value",
                     "id",
-                    "id.*",
                   ],
                   "lenient": true,
                   "query": "11111111-1111-1111-1111-111111111111",
@@ -1688,8 +1775,11 @@ Array [
               Object {
                 "multi_match": Object {
                   "fields": Array [
+                    "gender.code.keyword",
+                    "gender.coding.code.keyword",
+                    "gender.value.keyword",
+                    "gender.value",
                     "gender",
-                    "gender.*",
                   ],
                   "lenient": true,
                   "query": "female",
@@ -1811,8 +1901,11 @@ Array [
                     Object {
                       "multi_match": Object {
                         "fields": Array [
+                          "telecom.code.keyword",
+                          "telecom.coding.code.keyword",
+                          "telecom.value.keyword",
+                          "telecom.value",
                           "telecom",
-                          "telecom.*",
                         ],
                         "lenient": true,
                         "query": "1234567",

--- a/src/elasticSearchService.test.ts
+++ b/src/elasticSearchService.test.ts
@@ -43,6 +43,7 @@ describe('typeSearch', () => {
             [{ _count: 10, _getpagesoffset: 2 }],
             [{ gender: 'female', name: 'Emily' }],
             [{ gender: 'female', birthdate: 'gt1990' }],
+            [{ gender: 'female', identifier: 'http://acme.org/patient|2345' }],
             [{ _id: '11111111-1111-1111-1111-111111111111' }],
             [{ _format: 'json' }],
             [


### PR DESCRIPTION
Add support for token queries: https://www.hl7.org/fhir/search.html#token

the key feature is supporting `|` to indicate system and code:

> - **[parameter]=[code]**: the value of [code] matches a Coding.code or Identifier.value irrespective of the value of the system property
> - **[parameter]=[system]|[code]**: the value of [code] matches a Coding.code or Identifier.value, and the value of [system] matches the system property of the Identifier or Coding
> - **[parameter]=|[code]**: the value of [code] matches a Coding.code or Identifier.value, and the Coding/Identifier has no system property
> - **[parameter]=[system]|**: any element where the value of [system] matches the system property of the Identifier or Coding

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.