### PR TITLE
feat: allow sorting by date type parameters

### DIFF
--- a/src/QueryBuilder/index.ts
+++ b/src/QueryBuilder/index.ts
@@ -111,3 +111,5 @@ export const buildQueryForAllSearchParameters = (
         },
     };
 };
+
+export { buildSortClause } from './sort';

--- a/src/QueryBuilder/sort.test.ts
+++ b/src/QueryBuilder/sort.test.ts
@@ -42,7 +42,19 @@ describe('buildSortClause', () => {
                 },
               },
               Object {
+                "meta.lastUpdated.end": Object {
+                  "order": "desc",
+                  "unmapped_type": "long",
+                },
+              },
+              Object {
                 "birthDate": Object {
+                  "order": "asc",
+                  "unmapped_type": "long",
+                },
+              },
+              Object {
+                "birthDate.start": Object {
                   "order": "asc",
                   "unmapped_type": "long",
                 },

--- a/src/QueryBuilder/sort.test.ts
+++ b/src/QueryBuilder/sort.test.ts
@@ -1,0 +1,68 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { InvalidSearchParameterError } from 'fhir-works-on-aws-interface';
+import { buildSortClause, parseSortParameter } from './sort';
+import { FHIRSearchParametersRegistry } from '../FHIRSearchParametersRegistry';
+
+const fhirSearchParametersRegistry = new FHIRSearchParametersRegistry('4.0.1');
+
+describe('parseSortParameter', () => {
+    test('status,-date,category', () => {
+        expect(parseSortParameter('status,-date,category')).toMatchInlineSnapshot(`
+            Array [
+              Object {
+                "order": "asc",
+                "searchParam": "status",
+              },
+              Object {
+                "order": "desc",
+                "searchParam": "date",
+              },
+              Object {
+                "order": "asc",
+                "searchParam": "category",
+              },
+            ]
+        `);
+    });
+});
+
+describe('buildSortClause', () => {
+    test('valid date params', () => {
+        expect(buildSortClause(fhirSearchParametersRegistry, 'Patient', '-_lastUpdated,birthdate'))
+            .toMatchInlineSnapshot(`
+            Array [
+              Object {
+                "meta.lastUpdated": Object {
+                  "order": "desc",
+                  "unmapped_type": "long",
+                },
+              },
+              Object {
+                "birthDate": Object {
+                  "order": "asc",
+                  "unmapped_type": "long",
+                },
+              },
+            ]
+        `);
+    });
+
+    test('invalid params', () => {
+        [
+            'notAPatientParam',
+            '_lastUpdated,notAPatientParam',
+            '+birthdate',
+            '#$%/., symbols and stuff',
+            'valid params must match a param name from fhirSearchParametersRegistry, so most strings are invalid...',
+            'name', // This is actually a valid param but right now we only allow sorting by date params
+        ].forEach(p =>
+            expect(() => buildSortClause(fhirSearchParametersRegistry, 'Patient', p)).toThrow(
+                InvalidSearchParameterError,
+            ),
+        );
+    });
+});

--- a/src/QueryBuilder/sort.ts
+++ b/src/QueryBuilder/sort.ts
@@ -52,7 +52,7 @@ export const buildSortClause = (
         }
         if (searchParameter.type !== 'date') {
             throw new InvalidSearchParameterError(
-                `Invalid _sort parameter: ${sortParam.searchParam}. Only date type parameters can be used for sorting`,
+                `Invalid _sort parameter: ${sortParam.searchParam}. Only date type parameters can currently be used for sorting`,
             );
         }
         return searchParameter.compiled.flatMap(compiledParam => {

--- a/src/QueryBuilder/sort.ts
+++ b/src/QueryBuilder/sort.ts
@@ -1,0 +1,63 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { InvalidSearchParameterError } from 'fhir-works-on-aws-interface';
+import { FHIRSearchParametersRegistry } from '../FHIRSearchParametersRegistry';
+
+interface SortParameter {
+    order: 'asc' | 'desc';
+    searchParam: string;
+}
+
+export const parseSortParameter = (param: string): SortParameter[] => {
+    const parts = param.split(',');
+    return parts.map(s => {
+        const order = s.startsWith('-') ? 'desc' : 'asc';
+        return {
+            order,
+            searchParam: s.replace(/^-/, ''),
+        };
+    });
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export const buildSortClause = (
+    fhirSearchParametersRegistry: FHIRSearchParametersRegistry,
+    resourceType: string,
+    sortQueryParam: string | string[],
+    // request: TypeSearchRequest,
+): any => {
+    // const sortQueryParam = request.queryParams[SORT_PARAMETER];
+
+    if (Array.isArray(sortQueryParam)) {
+        throw new InvalidSearchParameterError('_sort parameter cannot be used multiple times on a search query');
+    }
+    const sortParams = parseSortParameter(sortQueryParam);
+
+    return sortParams.flatMap(sortParam => {
+        const searchParameter = fhirSearchParametersRegistry.getSearchParameter(resourceType, sortParam.searchParam);
+        if (searchParameter === undefined) {
+            throw new InvalidSearchParameterError(
+                `Unknown _sort parameter value: ${sortParam.searchParam}. Sort parameters values must use a valid Search Parameter`,
+            );
+        }
+        if (searchParameter.type !== 'date') {
+            throw new InvalidSearchParameterError(
+                `Invalid _sort parameter: ${sortParam.searchParam}. Only date type parameters can be used for sorting`,
+            );
+        }
+        return searchParameter.compiled.map(compiledParam => {
+            return {
+                [compiledParam.path]: {
+                    order: sortParam.order,
+                    // unmapped_type makes queries more fault tolerant. Since we are using dynamic mapping there's no guarantee
+                    // that the mapping exists at query time. This ignores the unmapped field instead of failing
+                    unmapped_type: 'long',
+                },
+            };
+        });
+    });
+};

--- a/src/QueryBuilder/sort.ts
+++ b/src/QueryBuilder/sort.ts
@@ -28,10 +28,7 @@ export const buildSortClause = (
     fhirSearchParametersRegistry: FHIRSearchParametersRegistry,
     resourceType: string,
     sortQueryParam: string | string[],
-    // request: TypeSearchRequest,
 ): any => {
-    // const sortQueryParam = request.queryParams[SORT_PARAMETER];
-
     if (Array.isArray(sortQueryParam)) {
         throw new InvalidSearchParameterError('_sort parameter cannot be used multiple times on a search query');
     }

--- a/src/__snapshots__/elasticSearchService.test.ts.snap
+++ b/src/__snapshots__/elasticSearchService.test.ts.snap
@@ -1466,7 +1466,7 @@ Array [
 ]
 `;
 
-exports[`typeSearch query snapshots for simple queryParams; with ACTIVE filter queryParams={"_count":10,"_getpagesoffset":2} 1`] = `
+exports[`typeSearch query snapshots for simple queryParams; with ACTIVE filter queryParams={"_count":10,"_getpagesoffset":2,"_sort":"_lastUpdated"} 1`] = `
 Array [
   Array [
     Object {
@@ -1483,6 +1483,14 @@ Array [
             "must": Array [],
           },
         },
+        "sort": Array [
+          Object {
+            "meta.lastUpdated": Object {
+              "order": "asc",
+              "unmapped_type": "long",
+            },
+          },
+        ],
       },
       "from": 2,
       "index": "patient",

--- a/src/__snapshots__/elasticSearchService.test.ts.snap
+++ b/src/__snapshots__/elasticSearchService.test.ts.snap
@@ -1490,6 +1490,12 @@ Array [
               "unmapped_type": "long",
             },
           },
+          Object {
+            "meta.lastUpdated.start": Object {
+              "order": "asc",
+              "unmapped_type": "long",
+            },
+          },
         ],
       },
       "from": 2,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,7 +12,9 @@ export const enum SEARCH_PAGINATION_PARAMS {
 
 export const SEPARATOR: string = '_';
 export const ITERATIVE_INCLUSION_PARAMETERS = ['_include:iterate', '_revinclude:iterate'];
+export const SORT_PARAMETER = '_sort';
 export const NON_SEARCHABLE_PARAMETERS = [
+    SORT_PARAMETER,
     SEARCH_PAGINATION_PARAMS.PAGES_OFFSET,
     SEARCH_PAGINATION_PARAMS.COUNT,
     '_format',

--- a/src/elasticSearchService.test.ts
+++ b/src/elasticSearchService.test.ts
@@ -40,7 +40,7 @@ describe('typeSearch', () => {
     describe('query snapshots for simple queryParams; with ACTIVE filter', () => {
         each([
             [{}],
-            [{ _count: 10, _getpagesoffset: 2 }],
+            [{ _count: 10, _getpagesoffset: 2, _sort: '_lastUpdated' }],
             [{ gender: 'female', name: 'Emily' }],
             [{ gender: 'female', birthdate: 'gt1990' }],
             [{ gender: 'female', identifier: 'http://acme.org/patient|2345' }],


### PR DESCRIPTION
see: https://www.hl7.org/fhir/search.html#sort

example: `GET [base]/Observation?_sort=status,-date,category`

only date is supported for now since that's the only one required to unblock `$docref`(plus, it may be the most useful for customers), I'll add a backlog item to support the other types.

**Edit:** updated to also work with fields of type Period (they have a `start` and an `end`) turns out that $docref needs that

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.