### PR TITLE
feat: support Period type fields for date params

### DIFF
--- a/src/QueryBuilder/typeQueries/dateQuery.test.ts
+++ b/src/QueryBuilder/typeQueries/dateQuery.test.ts
@@ -122,11 +122,37 @@ describe('dateQuery', () => {
     test('no prefix', () => {
         expect(dateQuery(birthdateParam, '1999-09-09')).toMatchInlineSnapshot(`
             Object {
-              "range": Object {
-                "birthDate": Object {
-                  "gte": 1999-09-09T00:00:00.000Z,
-                  "lte": 1999-09-09T23:59:59.999Z,
-                },
+              "bool": Object {
+                "should": Array [
+                  Object {
+                    "range": Object {
+                      "birthDate": Object {
+                        "gte": 1999-09-09T00:00:00.000Z,
+                        "lte": 1999-09-09T23:59:59.999Z,
+                      },
+                    },
+                  },
+                  Object {
+                    "bool": Object {
+                      "must": Array [
+                        Object {
+                          "range": Object {
+                            "birthDate.start": Object {
+                              "gte": 1999-09-09T00:00:00.000Z,
+                            },
+                          },
+                        },
+                        Object {
+                          "range": Object {
+                            "birthDate.end": Object {
+                              "lte": 1999-09-09T23:59:59.999Z,
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
               },
             }
         `);
@@ -134,17 +160,193 @@ describe('dateQuery', () => {
     test('eq', () => {
         expect(dateQuery(birthdateParam, 'eq1999-09-09')).toMatchInlineSnapshot(`
             Object {
-              "range": Object {
-                "birthDate": Object {
-                  "gte": 1999-09-09T00:00:00.000Z,
-                  "lte": 1999-09-09T23:59:59.999Z,
-                },
+              "bool": Object {
+                "should": Array [
+                  Object {
+                    "range": Object {
+                      "birthDate": Object {
+                        "gte": 1999-09-09T00:00:00.000Z,
+                        "lte": 1999-09-09T23:59:59.999Z,
+                      },
+                    },
+                  },
+                  Object {
+                    "bool": Object {
+                      "must": Array [
+                        Object {
+                          "range": Object {
+                            "birthDate.start": Object {
+                              "gte": 1999-09-09T00:00:00.000Z,
+                            },
+                          },
+                        },
+                        Object {
+                          "range": Object {
+                            "birthDate.end": Object {
+                              "lte": 1999-09-09T23:59:59.999Z,
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
               },
             }
         `);
     });
     test('ne', () => {
         expect(dateQuery(birthdateParam, 'ne1999-09-09')).toMatchInlineSnapshot(`
+            Object {
+              "bool": Object {
+                "should": Array [
+                  Object {
+                    "bool": Object {
+                      "should": Array [
+                        Object {
+                          "range": Object {
+                            "birthDate": Object {
+                              "gt": 1999-09-09T23:59:59.999Z,
+                            },
+                          },
+                        },
+                        Object {
+                          "range": Object {
+                            "birthDate": Object {
+                              "lt": 1999-09-09T00:00:00.000Z,
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                  Object {
+                    "bool": Object {
+                      "must_not": Object {
+                        "bool": Object {
+                          "must": Array [
+                            Object {
+                              "range": Object {
+                                "birthDate.start": Object {
+                                  "gte": 1999-09-09T00:00:00.000Z,
+                                },
+                              },
+                            },
+                            Object {
+                              "range": Object {
+                                "birthDate.end": Object {
+                                  "lte": 1999-09-09T23:59:59.999Z,
+                                },
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    },
+                  },
+                ],
+              },
+            }
+        `);
+    });
+    test('lt', () => {
+        expect(dateQuery(birthdateParam, 'lt1999-09-09')).toMatchInlineSnapshot(`
+            Object {
+              "bool": Object {
+                "should": Array [
+                  Object {
+                    "range": Object {
+                      "birthDate": Object {
+                        "lt": 1999-09-09T23:59:59.999Z,
+                      },
+                    },
+                  },
+                  Object {
+                    "range": Object {
+                      "birthDate.start": Object {
+                        "lte": 1999-09-09T23:59:59.999Z,
+                      },
+                    },
+                  },
+                ],
+              },
+            }
+        `);
+    });
+    test('le', () => {
+        expect(dateQuery(birthdateParam, 'le1999-09-09')).toMatchInlineSnapshot(`
+            Object {
+              "bool": Object {
+                "should": Array [
+                  Object {
+                    "range": Object {
+                      "birthDate": Object {
+                        "lte": 1999-09-09T23:59:59.999Z,
+                      },
+                    },
+                  },
+                  Object {
+                    "range": Object {
+                      "birthDate.start": Object {
+                        "lte": 1999-09-09T23:59:59.999Z,
+                      },
+                    },
+                  },
+                ],
+              },
+            }
+        `);
+    });
+    test('gt', () => {
+        expect(dateQuery(birthdateParam, 'gt1999-09-09')).toMatchInlineSnapshot(`
+            Object {
+              "bool": Object {
+                "should": Array [
+                  Object {
+                    "range": Object {
+                      "birthDate": Object {
+                        "gt": 1999-09-09T00:00:00.000Z,
+                      },
+                    },
+                  },
+                  Object {
+                    "range": Object {
+                      "birthDate.end": Object {
+                        "gte": 1999-09-09T00:00:00.000Z,
+                      },
+                    },
+                  },
+                ],
+              },
+            }
+        `);
+    });
+    test('ge', () => {
+        expect(dateQuery(birthdateParam, 'ge1999-09-09')).toMatchInlineSnapshot(`
+            Object {
+              "bool": Object {
+                "should": Array [
+                  Object {
+                    "range": Object {
+                      "birthDate": Object {
+                        "gte": 1999-09-09T00:00:00.000Z,
+                      },
+                    },
+                  },
+                  Object {
+                    "range": Object {
+                      "birthDate.end": Object {
+                        "gte": 1999-09-09T00:00:00.000Z,
+                      },
+                    },
+                  },
+                ],
+              },
+            }
+        `);
+    });
+    test('sa', () => {
+        expect(dateQuery(birthdateParam, 'sa1999-09-09')).toMatchInlineSnapshot(`
             Object {
               "bool": Object {
                 "should": Array [
@@ -157,8 +359,8 @@ describe('dateQuery', () => {
                   },
                   Object {
                     "range": Object {
-                      "birthDate": Object {
-                        "lt": 1999-09-09T00:00:00.000Z,
+                      "birthDate.start": Object {
+                        "gt": 1999-09-09T23:59:59.999Z,
                       },
                     },
                   },
@@ -167,68 +369,26 @@ describe('dateQuery', () => {
             }
         `);
     });
-    test('lt', () => {
-        expect(dateQuery(birthdateParam, 'lt1999-09-09')).toMatchInlineSnapshot(`
-            Object {
-              "range": Object {
-                "birthDate": Object {
-                  "lt": 1999-09-09T23:59:59.999Z,
-                },
-              },
-            }
-        `);
-    });
-    test('le', () => {
-        expect(dateQuery(birthdateParam, 'le1999-09-09')).toMatchInlineSnapshot(`
-            Object {
-              "range": Object {
-                "birthDate": Object {
-                  "lte": 1999-09-09T23:59:59.999Z,
-                },
-              },
-            }
-        `);
-    });
-    test('gt', () => {
-        expect(dateQuery(birthdateParam, 'gt1999-09-09')).toMatchInlineSnapshot(`
-            Object {
-              "range": Object {
-                "birthDate": Object {
-                  "gt": 1999-09-09T00:00:00.000Z,
-                },
-              },
-            }
-        `);
-    });
-    test('ge', () => {
-        expect(dateQuery(birthdateParam, 'ge1999-09-09')).toMatchInlineSnapshot(`
-            Object {
-              "range": Object {
-                "birthDate": Object {
-                  "gte": 1999-09-09T00:00:00.000Z,
-                },
-              },
-            }
-        `);
-    });
-    test('sa', () => {
-        expect(dateQuery(birthdateParam, 'sa1999-09-09')).toMatchInlineSnapshot(`
-            Object {
-              "range": Object {
-                "birthDate": Object {
-                  "gt": 1999-09-09T23:59:59.999Z,
-                },
-              },
-            }
-        `);
-    });
     test('eb', () => {
         expect(dateQuery(birthdateParam, 'eb1999-09-09')).toMatchInlineSnapshot(`
             Object {
-              "range": Object {
-                "birthDate": Object {
-                  "lt": 1999-09-09T00:00:00.000Z,
-                },
+              "bool": Object {
+                "should": Array [
+                  Object {
+                    "range": Object {
+                      "birthDate": Object {
+                        "lt": 1999-09-09T00:00:00.000Z,
+                      },
+                    },
+                  },
+                  Object {
+                    "range": Object {
+                      "birthDate.end": Object {
+                        "lt": 1999-09-09T00:00:00.000Z,
+                      },
+                    },
+                  },
+                ],
               },
             }
         `);

--- a/src/__snapshots__/elasticSearchService.test.ts.snap
+++ b/src/__snapshots__/elasticSearchService.test.ts.snap
@@ -1587,10 +1587,23 @@ Array [
                 },
               },
               Object {
-                "range": Object {
-                  "birthDate": Object {
-                    "gt": 1990-01-01T00:00:00.000Z,
-                  },
+                "bool": Object {
+                  "should": Array [
+                    Object {
+                      "range": Object {
+                        "birthDate": Object {
+                          "gt": 1990-01-01T00:00:00.000Z,
+                        },
+                      },
+                    },
+                    Object {
+                      "range": Object {
+                        "birthDate.end": Object {
+                          "gte": 1990-01-01T00:00:00.000Z,
+                        },
+                      },
+                    },
+                  ],
                 },
               },
             ],


### PR DESCRIPTION
Enhance the date queries to work with fields of type Period(they have `start` and `end` datetime values). This means that queries are matching the range of the period against the implicit range of the date parameter.

See the interpretation of prefixes when applied to ranges: https://www.hl7.org/fhir/search.html#prefix. It can be counterintuitive at first

**Note:** we rely on dynamic mapping and we don't know always know if a given field is a date or a period, so queries include clauses for both. clauses for invalid fields are simply ignored. The query results are correct, but queries can be simplified once we have static mapping and know the exact type of all fields.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.