### PR TITLE
feat: allow repeated search parameters

### DIFF
--- a/src/__snapshots__/elasticSearchService.test.ts.snap
+++ b/src/__snapshots__/elasticSearchService.test.ts.snap
@@ -1403,7 +1403,7 @@ Array [
 ]
 `;
 
-exports[`typeSearch query snapshots for simple queryParams; with ACTIVE filter queryParams={"_count":10,"_getpagesoffset":2,"_id":"11111111-1111-1111-1111-111111111111","gender":"female","name":"Emily","_format":"json"} 1`] = `
+exports[`typeSearch query snapshots for simple queryParams; with ACTIVE filter queryParams={"_count":"10","_getpagesoffset":"2","_id":"11111111-1111-1111-1111-111111111111","gender":"female","name":"Emily","_format":"json"} 1`] = `
 Array [
   Array [
     Object {
@@ -1466,7 +1466,7 @@ Array [
 ]
 `;
 
-exports[`typeSearch query snapshots for simple queryParams; with ACTIVE filter queryParams={"_count":10,"_getpagesoffset":2,"_sort":"_lastUpdated"} 1`] = `
+exports[`typeSearch query snapshots for simple queryParams; with ACTIVE filter queryParams={"_count":"10","_getpagesoffset":"2","_sort":"_lastUpdated"} 1`] = `
 Array [
   Array [
     Object {
@@ -1751,6 +1751,66 @@ Array [
 ]
 `;
 
+exports[`typeSearch query snapshots for simple queryParams; with ACTIVE filter queryParams={"gender":"female","name":["Emily","Smith"]} 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [
+              Object {
+                "multi_match": Object {
+                  "fields": Array [
+                    "gender.code.keyword",
+                    "gender.coding.code.keyword",
+                    "gender.value.keyword",
+                    "gender.value",
+                    "gender",
+                  ],
+                  "lenient": true,
+                  "query": "female",
+                },
+              },
+              Object {
+                "multi_match": Object {
+                  "fields": Array [
+                    "name",
+                    "name.*",
+                  ],
+                  "lenient": true,
+                  "query": "Emily",
+                },
+              },
+              Object {
+                "multi_match": Object {
+                  "fields": Array [
+                    "name",
+                    "name.*",
+                  ],
+                  "lenient": true,
+                  "query": "Smith",
+                },
+              },
+            ],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient",
+      "size": 20,
+    },
+  ],
+]
+`;
+
 exports[`typeSearch query snapshots for simple queryParams; with ACTIVE filter queryParams={} 1`] = `
 Array [
   Array [
@@ -1777,7 +1837,7 @@ Array [
 ]
 `;
 
-exports[`typeSearch query snapshots for simple queryParams; without ACTIVE filter queryParams={"_count":10,"_getpagesoffset":2,"_id":"11111111-1111-1111-1111-111111111111","gender":"female","name":"Emily","_format":"json"} 1`] = `
+exports[`typeSearch query snapshots for simple queryParams; without ACTIVE filter queryParams={"_count":"10","_getpagesoffset":"2","_id":"11111111-1111-1111-1111-111111111111","gender":"female","name":"Emily","_format":"json"} 1`] = `
 Array [
   Array [
     Object {

--- a/src/elasticSearchService.test.ts
+++ b/src/elasticSearchService.test.ts
@@ -40,16 +40,17 @@ describe('typeSearch', () => {
     describe('query snapshots for simple queryParams; with ACTIVE filter', () => {
         each([
             [{}],
-            [{ _count: 10, _getpagesoffset: 2, _sort: '_lastUpdated' }],
+            [{ _count: '10', _getpagesoffset: '2', _sort: '_lastUpdated' }],
             [{ gender: 'female', name: 'Emily' }],
+            [{ gender: 'female', name: ['Emily', 'Smith'] }],
             [{ gender: 'female', birthdate: 'gt1990' }],
             [{ gender: 'female', identifier: 'http://acme.org/patient|2345' }],
             [{ _id: '11111111-1111-1111-1111-111111111111' }],
             [{ _format: 'json' }],
             [
                 {
-                    _count: 10,
-                    _getpagesoffset: 2,
+                    _count: '10',
+                    _getpagesoffset: '2',
                     _id: '11111111-1111-1111-1111-111111111111',
                     gender: 'female',
                     name: 'Emily',
@@ -98,8 +99,8 @@ describe('typeSearch', () => {
             [{}],
             [
                 {
-                    _count: 10,
-                    _getpagesoffset: 2,
+                    _count: '10',
+                    _getpagesoffset: '2',
                     _id: '11111111-1111-1111-1111-111111111111',
                     gender: 'female',
                     name: 'Emily',


### PR DESCRIPTION
https://www.hl7.org/fhir/search.html#combining

If a parameter repeats, such as `/Patient?language=FR&language=NL`, then this matches a patient who speaks both languages. This is known as an AND search parameter, since the server is expected to respond only with results which match both values.

Change is actually fairly small since multiple different search parameters are combined with AND anyways

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.