### PR TITLE
feat: accept Elasticsearch client as optional constructor argument

### DIFF
--- a/src/elasticSearchService.ts
+++ b/src/elasticSearchService.ts
@@ -161,7 +161,6 @@ export class ElasticSearchService implements Search {
     // eslint-disable-next-line class-methods-use-this
     private async executeQuery(searchQuery: any): Promise<{ hits: any[]; total: number }> {
         try {
-            console.log(`Query: ${JSON.stringify(searchQuery, null, 2)}`);
             const apiResponse = await this.esClient.search(searchQuery);
             return {
                 total: apiResponse.body.hits.total.value,


### PR DESCRIPTION
Description of changes:
To support testing against a local ElasticSearch instance allow passing a Client instance to the ElasticSearchService constructor. 
Should not be a breaking change.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.