### PR TITLE
fix: use exact string matching for references

### DIFF
--- a/src/QueryBuilder/index.ts
+++ b/src/QueryBuilder/index.ts
@@ -11,6 +11,7 @@ import { dateQuery } from './typeQueries/dateQuery';
 import { tokenQuery } from './typeQueries/tokenQuery';
 import { numberQuery } from './typeQueries/numberQuery';
 import { quantityQuery } from './typeQueries/quantityQuery';
+import { referenceQuery } from './typeQueries/referenceQuery';
 
 function typeQueryWithConditions(
     searchParam: SearchParam,
@@ -34,8 +35,10 @@ function typeQueryWithConditions(
         case 'quantity':
             typeQuery = quantityQuery(compiledSearchParam, searchValue);
             break;
-        case 'composite':
         case 'reference':
+            typeQuery = referenceQuery(compiledSearchParam, searchValue);
+            break;
+        case 'composite':
         case 'special':
         case 'uri':
         default:

--- a/src/QueryBuilder/typeQueries/referenceQuery.test.ts
+++ b/src/QueryBuilder/typeQueries/referenceQuery.test.ts
@@ -1,0 +1,26 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { referenceQuery } from './referenceQuery';
+import { FHIRSearchParametersRegistry } from '../../FHIRSearchParametersRegistry';
+
+const fhirSearchParametersRegistry = new FHIRSearchParametersRegistry('4.0.1');
+const organizationParam = fhirSearchParametersRegistry.getSearchParameter('Patient', 'organization')!.compiled[0];
+
+describe('referenceQuery', () => {
+    test('simple value', () => {
+        expect(referenceQuery(organizationParam, 'Organization/111')).toMatchInlineSnapshot(`
+            Object {
+              "multi_match": Object {
+                "fields": Array [
+                  "managingOrganization.reference.keyword",
+                ],
+                "lenient": true,
+                "query": "Organization/111",
+              },
+            }
+        `);
+    });
+});

--- a/src/QueryBuilder/typeQueries/referenceQuery.ts
+++ b/src/QueryBuilder/typeQueries/referenceQuery.ts
@@ -1,0 +1,18 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CompiledSearchParam } from '../../FHIRSearchParametersRegistry';
+
+// eslint-disable-next-line import/prefer-default-export
+export function referenceQuery(compiled: CompiledSearchParam, value: string): any {
+    const fields = [`${compiled.path}.reference.keyword`];
+    return {
+        multi_match: {
+            fields,
+            query: value,
+            lenient: true,
+        },
+    };
+}

--- a/src/__snapshots__/elasticSearchService.test.ts.snap
+++ b/src/__snapshots__/elasticSearchService.test.ts.snap
@@ -1941,8 +1941,7 @@ Array [
                     Object {
                       "multi_match": Object {
                         "fields": Array [
-                          "relatedArtifact.resource",
-                          "relatedArtifact.resource.*",
+                          "relatedArtifact.resource.reference.keyword",
                         ],
                         "lenient": true,
                         "query": "something",
@@ -2049,11 +2048,10 @@ Array [
                     Object {
                       "multi_match": Object {
                         "fields": Array [
-                          "link.target",
-                          "link.target.*",
+                          "link.target.reference.keyword",
                         ],
                         "lenient": true,
-                        "query": "RelatedPerson\\\\/111",
+                        "query": "RelatedPerson/111",
                       },
                     },
                     Object {


### PR DESCRIPTION
Description of changes:

Using full text search for references was giving bad results.

Note: There are other aspects of the reference search params syntax that we are not implementing just yet: https://www.hl7.org/fhir/search.html#reference. Using exact string matching is a high priority change that unblocks the most common use cases

related: https://github.com/awslabs/fhir-works-on-aws-deployment/issues/329

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.