### PR TITLE
feat: implement multi-tenancy

### DIFF
--- a/src/__snapshots__/elasticSearchService.test.ts.snap
+++ b/src/__snapshots__/elasticSearchService.test.ts.snap
@@ -1299,6 +1299,316 @@ Array [
 ]
 `;
 
+exports[`typeSearch multi-tenancy enabled: _include:iterate: msearch queries 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Array [
+        Object {
+          "index": "patient-alias-tenant-tenant1",
+        },
+        Object {
+          "query": Object {
+            "bool": Object {
+              "filter": Array [
+                Object {
+                  "terms": Object {
+                    "id": Array [
+                      "patient-id-333",
+                    ],
+                  },
+                },
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+                Object {
+                  "match": Object {
+                    "_tenantId.keyword": "tenant1",
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+  ],
+  Array [
+    Object {
+      "body": Array [
+        Object {
+          "index": "organization-alias-tenant-tenant1",
+        },
+        Object {
+          "query": Object {
+            "bool": Object {
+              "filter": Array [
+                Object {
+                  "terms": Object {
+                    "id": Array [
+                      "org-id-111",
+                    ],
+                  },
+                },
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+                Object {
+                  "match": Object {
+                    "_tenantId.keyword": "tenant1",
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+  ],
+]
+`;
+
+exports[`typeSearch multi-tenancy enabled: _include:iterate: search queries 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+              Object {
+                "match": Object {
+                  "_tenantId.keyword": "tenant1",
+                },
+              },
+            ],
+            "must": Array [],
+          },
+        },
+      },
+      "from": 0,
+      "index": "medicationrequest-alias-tenant-tenant1",
+      "size": 20,
+      "track_total_hits": true,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch multi-tenancy enabled: _revinclude:iterate: msearch queries 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Array [
+        Object {
+          "index": "medicationadministration-alias-tenant-tenant1",
+        },
+        Object {
+          "query": Object {
+            "bool": Object {
+              "filter": Array [
+                Object {
+                  "terms": Object {
+                    "request.reference.keyword": Array [
+                      "MedicationRequest/medicationrequest-id-111",
+                    ],
+                  },
+                },
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+                Object {
+                  "match": Object {
+                    "_tenantId.keyword": "tenant1",
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+  ],
+  Array [
+    Object {
+      "body": Array [
+        Object {
+          "index": "medicationstatement-alias-tenant-tenant1",
+        },
+        Object {
+          "query": Object {
+            "bool": Object {
+              "filter": Array [
+                Object {
+                  "terms": Object {
+                    "partOf.reference.keyword": Array [
+                      "MedicationAdministration/medication-administration-111",
+                    ],
+                  },
+                },
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+                Object {
+                  "match": Object {
+                    "_tenantId.keyword": "tenant1",
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+  ],
+]
+`;
+
+exports[`typeSearch multi-tenancy enabled: _revinclude:iterate: search queries 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+              Object {
+                "match": Object {
+                  "_tenantId.keyword": "tenant1",
+                },
+              },
+            ],
+            "must": Array [],
+          },
+        },
+      },
+      "from": 0,
+      "index": "medicationrequest-alias-tenant-tenant1",
+      "size": 20,
+      "track_total_hits": true,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch multi-tenancy enabled: simple queries queryParams={"_id":"11111111-1111-1111-1111-111111111111"} 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+              Object {
+                "match": Object {
+                  "_tenantId.keyword": "tenant1",
+                },
+              },
+            ],
+            "must": Array [
+              Object {
+                "multi_match": Object {
+                  "fields": Array [
+                    "id.code.keyword",
+                    "id.coding.code.keyword",
+                    "id.value.keyword",
+                    "id",
+                  ],
+                  "lenient": true,
+                  "query": "11111111-1111-1111-1111-111111111111",
+                },
+              },
+            ],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient-alias-tenant-tenant1",
+      "size": 20,
+      "track_total_hits": true,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch multi-tenancy enabled: simple queries queryParams={"gender":"female","name":"Emily"} 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+              Object {
+                "match": Object {
+                  "_tenantId.keyword": "tenant1",
+                },
+              },
+            ],
+            "must": Array [
+              Object {
+                "multi_match": Object {
+                  "fields": Array [
+                    "gender.code.keyword",
+                    "gender.coding.code.keyword",
+                    "gender.value.keyword",
+                    "gender",
+                  ],
+                  "lenient": true,
+                  "query": "female",
+                },
+              },
+              Object {
+                "multi_match": Object {
+                  "fields": Array [
+                    "name",
+                    "name.*",
+                  ],
+                  "lenient": true,
+                  "query": "Emily",
+                },
+              },
+            ],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient-alias-tenant-tenant1",
+      "size": 20,
+      "track_total_hits": true,
+    },
+  ],
+]
+`;
+
 exports[`typeSearch query snapshots for no queryParams, ACTIVE filter & changing filters filterParams=[] 1`] = `
 Array [
   Array [

--- a/src/elasticSearchService.test.ts
+++ b/src/elasticSearchService.test.ts
@@ -524,6 +524,84 @@ describe('typeSearch', () => {
         expect((ElasticSearch.msearch as jest.Mock).mock.calls).toMatchSnapshot('msearch queries');
     });
 
+    test('multi-tenancy enabled: _include:iterate', async () => {
+        (ElasticSearch.search as jest.Mock).mockResolvedValue(fakeMedicationRequestSearchResult);
+        (ElasticSearch.msearch as jest.Mock).mockResolvedValueOnce({
+            body: {
+                took: 0,
+                responses: [
+                    {
+                        hits: {
+                            total: {
+                                value: 1,
+                                relation: 'eq',
+                            },
+                            max_score: 0,
+                            hits: [
+                                {
+                                    _source: {
+                                        id: 'patient-id-333',
+                                        resourceType: 'Patient',
+                                        managingOrganization: {
+                                            reference: 'Organization/org-id-111',
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                        status: 200,
+                    },
+                ],
+            },
+        });
+        (ElasticSearch.msearch as jest.Mock).mockResolvedValueOnce({
+            body: {
+                took: 0,
+                responses: [
+                    {
+                        hits: {
+                            total: {
+                                value: 1,
+                                relation: 'eq',
+                            },
+                            max_score: 0,
+                            hits: [
+                                {
+                                    _source: {
+                                        id: 'org-id-111',
+                                        resourceType: 'Organization',
+                                    },
+                                },
+                            ],
+                        },
+                        status: 200,
+                    },
+                ],
+            },
+        });
+        const queryParams = { '_include:iterate': ['MedicationRequest:subject', 'Patient:organization'] };
+        const es = new ElasticSearchService(
+            FILTER_RULES_FOR_ACTIVE_RESOURCES,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            {
+                enableMultiTenancy: true,
+            },
+        );
+        await es.typeSearch({
+            resourceType: 'MedicationRequest',
+            baseUrl: 'https://base-url.com',
+            queryParams: { ...queryParams },
+            allowedResourceTypes: ALLOWED_RESOURCE_TYPES,
+            tenantId: 'tenant1',
+        });
+
+        expect((ElasticSearch.search as jest.Mock).mock.calls).toMatchSnapshot('search queries');
+        expect((ElasticSearch.msearch as jest.Mock).mock.calls).toMatchSnapshot('msearch queries');
+    });
+
     test('_revinclude:iterate', async () => {
         (ElasticSearch.search as jest.Mock).mockResolvedValue(fakeMedicationRequestSearchResult);
         (ElasticSearch.msearch as jest.Mock).mockResolvedValueOnce({
@@ -581,6 +659,79 @@ describe('typeSearch', () => {
             baseUrl: 'https://base-url.com',
             queryParams: { ...queryParams },
             allowedResourceTypes: ALLOWED_RESOURCE_TYPES,
+        });
+
+        expect((ElasticSearch.search as jest.Mock).mock.calls).toMatchSnapshot('search queries');
+        expect((ElasticSearch.msearch as jest.Mock).mock.calls).toMatchSnapshot('msearch queries');
+    });
+
+    test('multi-tenancy enabled: _revinclude:iterate', async () => {
+        (ElasticSearch.search as jest.Mock).mockResolvedValue(fakeMedicationRequestSearchResult);
+        (ElasticSearch.msearch as jest.Mock).mockResolvedValueOnce({
+            body: {
+                took: 0,
+                responses: [
+                    {
+                        hits: {
+                            total: {
+                                value: 1,
+                                relation: 'eq',
+                            },
+                            max_score: 0,
+                            hits: [
+                                {
+                                    _source: {
+                                        id: 'medication-administration-111',
+                                        resourceType: 'MedicationAdministration',
+                                    },
+                                },
+                            ],
+                        },
+                        status: 200,
+                    },
+                ],
+            },
+        });
+        (ElasticSearch.msearch as jest.Mock).mockResolvedValueOnce({
+            body: {
+                took: 0,
+                responses: [
+                    {
+                        hits: {
+                            total: {
+                                value: 1,
+                                relation: 'eq',
+                            },
+                            max_score: 0,
+                            hits: [],
+                        },
+                        status: 200,
+                    },
+                ],
+            },
+        });
+        const queryParams = {
+            '_revinclude:iterate': [
+                'MedicationAdministration:request:MedicationRequest',
+                'MedicationStatement:part-of:MedicationAdministration',
+            ],
+        };
+        const es = new ElasticSearchService(
+            FILTER_RULES_FOR_ACTIVE_RESOURCES,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            {
+                enableMultiTenancy: true,
+            },
+        );
+        await es.typeSearch({
+            resourceType: 'MedicationRequest',
+            baseUrl: 'https://base-url.com',
+            queryParams: { ...queryParams },
+            allowedResourceTypes: ALLOWED_RESOURCE_TYPES,
+            tenantId: 'tenant1',
         });
 
         expect((ElasticSearch.search as jest.Mock).mock.calls).toMatchSnapshot('search queries');
@@ -713,5 +864,57 @@ describe('typeSearch', () => {
 
             expect((ElasticSearch.search as jest.Mock).mock.calls).toMatchSnapshot();
         });
+    });
+
+    describe('multi-tenancy enabled: simple queries', () => {
+        each([[{ gender: 'female', name: 'Emily' }], [{ _id: '11111111-1111-1111-1111-111111111111' }]]).test(
+            'queryParams=%j',
+            async (queryParams: any) => {
+                const fakeSearchResult = {
+                    body: {
+                        hits: {
+                            total: {
+                                value: 1,
+                                relation: 'eq',
+                            },
+                            max_score: 1,
+                            hits: [
+                                {
+                                    _index: 'patient',
+                                    _type: '_doc',
+                                    _id: 'ab69afd3-39ed-42c3-9f77-8a718a247742_1',
+                                    _score: 1,
+                                    _source: {
+                                        vid: '1',
+                                        id: 'ab69afd3-39ed-42c3-9f77-8a718a247742',
+                                        resourceType: 'Patient',
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                };
+                (ElasticSearch.search as jest.Mock).mockResolvedValue(fakeSearchResult);
+                const es = new ElasticSearchService(
+                    FILTER_RULES_FOR_ACTIVE_RESOURCES,
+                    undefined,
+                    undefined,
+                    undefined,
+                    undefined,
+                    {
+                        enableMultiTenancy: true,
+                    },
+                );
+                await es.typeSearch({
+                    resourceType: 'Patient',
+                    baseUrl: 'https://base-url.com',
+                    queryParams,
+                    allowedResourceTypes: ALLOWED_RESOURCE_TYPES,
+                    tenantId: 'tenant1',
+                });
+
+                expect((ElasticSearch.search as jest.Mock).mock.calls).toMatchSnapshot();
+            },
+        );
     });
 });

--- a/src/elasticSearchService.ts
+++ b/src/elasticSearchService.ts
@@ -117,7 +117,7 @@ export class ElasticSearchService implements Search {
         if (this.enableMultiTenancy) {
             filters.push({
                 match: {
-                    '_tenantId.keyword': tenantId,
+                    _tenantId: tenantId,
                 },
             });
         }

--- a/src/elasticSearchService.ts
+++ b/src/elasticSearchService.ts
@@ -19,7 +19,7 @@ import {
     FhirVersion,
     InvalidSearchParameterError,
 } from 'fhir-works-on-aws-interface';
-import { Client } from '@elastic/elasticsearch';
+import { Client, RequestParams } from '@elastic/elasticsearch';
 import { ElasticSearch } from './elasticSearch';
 import {
     DEFAULT_SEARCH_RESULTS_PER_PAGE,
@@ -33,9 +33,22 @@ import { FHIRSearchParametersRegistry } from './FHIRSearchParametersRegistry';
 import { buildQueryForAllSearchParameters, buildSortClause } from './QueryBuilder';
 import getComponentLogger from './loggerBuilder';
 
+export type Query = {
+    resourceType: string;
+    queryRequest: RequestParams.Search<Record<string, any>>;
+};
+
 const logger = getComponentLogger();
 
 const MAX_INCLUDE_ITERATIVE_DEPTH = 5;
+
+const getAliasName = (resourceType: string, tenantId?: string) => {
+    const lowercaseResourceType = resourceType.toLowerCase();
+    if (tenantId) {
+        return `${lowercaseResourceType}-alias-tenant-${tenantId}`;
+    }
+    return `${lowercaseResourceType}-alias`;
+};
 
 // eslint-disable-next-line import/prefer-default-export
 export class ElasticSearchService implements Search {
@@ -49,6 +62,8 @@ export class ElasticSearchService implements Search {
 
     private readonly fhirSearchParametersRegistry: FHIRSearchParametersRegistry;
 
+    private readonly enableMultiTenancy: boolean;
+
     /**
      * @param searchFiltersForAllQueries - If you are storing both History and Search resources
      * in your elastic search you can filter out your History elements by supplying a list of SearchFilters
@@ -59,6 +74,7 @@ export class ElasticSearchService implements Search {
      * @param compiledImplementationGuides - The output of ImplementationGuides.compile.
      * This parameter enables support for search parameters defined in Implementation Guides.
      * @param esClient
+     * @param options.enableMultiTenancy - whether or not to enable multi-tenancy. When enabled a tenantId is required for all requests.
      */
     constructor(
         searchFiltersForAllQueries: SearchFilter[] = [],
@@ -68,23 +84,53 @@ export class ElasticSearchService implements Search {
         fhirVersion: FhirVersion = '4.0.1',
         compiledImplementationGuides?: any,
         esClient: Client = ElasticSearch,
+        { enableMultiTenancy = false }: { enableMultiTenancy?: boolean } = {},
     ) {
         this.searchFiltersForAllQueries = searchFiltersForAllQueries;
         this.cleanUpFunction = cleanUpFunction;
         this.fhirVersion = fhirVersion;
         this.fhirSearchParametersRegistry = new FHIRSearchParametersRegistry(fhirVersion, compiledImplementationGuides);
         this.esClient = esClient;
+        this.enableMultiTenancy = enableMultiTenancy;
+    }
+
+    private assertValidTenancyMode(tenantId?: string) {
+        if (this.enableMultiTenancy && tenantId === undefined) {
+            throw new Error('This instance has multi-tenancy enabled, but the incoming request is missing tenantId');
+        }
+        if (!this.enableMultiTenancy && tenantId !== undefined) {
+            throw new Error('This instance has multi-tenancy disabled, but the incoming request has a tenantId');
+        }
     }
 
     async getCapabilities() {
         return this.fhirSearchParametersRegistry.getCapabilities();
     }
 
+    private getFilters(request: TypeSearchRequest) {
+        const { searchFilters, tenantId } = request;
+        const filters: any[] = ElasticSearchService.buildElasticSearchFilter([
+            ...this.searchFiltersForAllQueries,
+            ...(searchFilters ?? []),
+        ]);
+
+        if (this.enableMultiTenancy) {
+            filters.push({
+                match: {
+                    '_tenantId.keyword': tenantId,
+                },
+            });
+        }
+
+        return filters;
+    }
+
     /*
     searchParams => {field: value}
      */
     async typeSearch(request: TypeSearchRequest): Promise<SearchResponse> {
-        const { queryParams, searchFilters, resourceType } = request;
+        this.assertValidTenancyMode(request.tenantId);
+        const { queryParams, resourceType } = request;
         try {
             const from = queryParams[SEARCH_PAGINATION_PARAMS.PAGES_OFFSET]
                 ? Number(queryParams[SEARCH_PAGINATION_PARAMS.PAGES_OFFSET])
@@ -104,31 +150,31 @@ export class ElasticSearchService implements Search {
                 );
             }
 
-            const filter: any[] = ElasticSearchService.buildElasticSearchFilter([
-                ...this.searchFiltersForAllQueries,
-                ...(searchFilters ?? []),
-            ]);
+            const filter = this.getFilters(request);
+
             const query = buildQueryForAllSearchParameters(this.fhirSearchParametersRegistry, request, filter);
 
-            const params: any = {
-                index: `${resourceType.toLowerCase()}-alias`,
-                from,
-                size,
-                track_total_hits: true,
-                body: {
-                    query,
+            const params: Query = {
+                resourceType,
+                queryRequest: {
+                    from,
+                    size,
+                    track_total_hits: true,
+                    body: {
+                        query,
+                    },
                 },
             };
 
             if (request.queryParams[SORT_PARAMETER]) {
-                params.body.sort = buildSortClause(
+                params.queryRequest.body!.sort = buildSortClause(
                     this.fhirSearchParametersRegistry,
                     resourceType,
                     request.queryParams[SORT_PARAMETER],
                 );
             }
 
-            const { total, hits } = await this.executeQuery(params);
+            const { total, hits } = await this.executeQuery(params, request);
             const result: SearchResult = {
                 numberOfResults: total,
                 entries: this.hitsToSearchEntries({ hits, baseUrl: request.baseUrl, mode: 'match' }),
@@ -172,12 +218,20 @@ export class ElasticSearchService implements Search {
     }
 
     // eslint-disable-next-line class-methods-use-this
-    private async executeQuery(searchQuery: any): Promise<{ hits: any[]; total: number }> {
+    private async executeQuery(
+        searchQuery: Query,
+        request: TypeSearchRequest,
+    ): Promise<{ hits: any[]; total: number }> {
         try {
+            const searchQueryWithAlias = {
+                ...searchQuery.queryRequest,
+                index: getAliasName(searchQuery.resourceType, request.tenantId),
+            };
+
             if (logger.isDebugEnabled()) {
-                logger.debug(`Elastic search query: ${JSON.stringify(searchQuery, null, 2)}`);
+                logger.debug(`Elastic search query: ${JSON.stringify(searchQueryWithAlias, null, 2)}`);
             }
-            const apiResponse = await this.esClient.search(searchQuery);
+            const apiResponse = await this.esClient.search(searchQueryWithAlias);
             return {
                 total: apiResponse.body.hits.total.value,
                 hits: apiResponse.body.hits.hits,
@@ -185,7 +239,9 @@ export class ElasticSearchService implements Search {
         } catch (error) {
             // Indexes are created the first time a resource of a given type is written to DDB.
             if (error instanceof ResponseError && error.message === 'index_not_found_exception') {
-                logger.info(`Search index for ${searchQuery.index} does not exist. Returning an empty search result`);
+                logger.info(
+                    `Search index for ${searchQuery.queryRequest.index} does not exist. Returning an empty search result`,
+                );
                 return {
                     total: 0,
                     hits: [],
@@ -197,17 +253,23 @@ export class ElasticSearchService implements Search {
     }
 
     // eslint-disable-next-line class-methods-use-this
-    private async executeQueries(searchQueries: any[]): Promise<{ hits: any[] }> {
+    private async executeQueries(searchQueries: Query[], request: TypeSearchRequest): Promise<{ hits: any[] }> {
         if (searchQueries.length === 0) {
             return {
                 hits: [],
             };
         }
+
+        const searchQueriesWithAlias = searchQueries.map(searchQuery => ({
+            ...searchQuery.queryRequest,
+            index: getAliasName(searchQuery.resourceType, request.tenantId),
+        }));
+
         if (logger.isDebugEnabled()) {
-            logger.debug(`Elastic msearch query: ${JSON.stringify(searchQueries, null, 2)}`);
+            logger.debug(`Elastic msearch query: ${JSON.stringify(searchQueriesWithAlias, null, 2)}`);
         }
         const apiResponse = await this.esClient.msearch({
-            body: searchQueries.flatMap(query => [{ index: query.index }, { query: query.body.query }]),
+            body: searchQueriesWithAlias.flatMap(query => [{ index: query.index }, { query: query.body!.query }]),
         });
 
         return (apiResponse.body.responses as any[])
@@ -267,13 +329,10 @@ export class ElasticSearchService implements Search {
         request: TypeSearchRequest,
         iterative?: true,
     ): Promise<SearchEntry[]> {
-        const { queryParams, searchFilters, allowedResourceTypes, baseUrl } = request;
-        const filter: any[] = ElasticSearchService.buildElasticSearchFilter([
-            ...this.searchFiltersForAllQueries,
-            ...(searchFilters ?? []),
-        ]);
+        const { queryParams, allowedResourceTypes, baseUrl } = request;
+        const filter: any[] = this.getFilters(request);
 
-        const includeSearchQueries = buildIncludeQueries(
+        const includeSearchQueries: Query[] = buildIncludeQueries(
             queryParams,
             searchEntries.map(x => x.resource),
             filter,
@@ -281,7 +340,7 @@ export class ElasticSearchService implements Search {
             iterative,
         );
 
-        const revIncludeSearchQueries = buildRevIncludeQueries(
+        const revIncludeSearchQueries: Query[] = buildRevIncludeQueries(
             queryParams,
             searchEntries.map(x => x.resource),
             filter,
@@ -291,10 +350,10 @@ export class ElasticSearchService implements Search {
 
         const lowerCaseAllowedResourceTypes = new Set(allowedResourceTypes.map((r: string) => r.toLowerCase()));
         const allowedInclusionQueries = [...includeSearchQueries, ...revIncludeSearchQueries].filter(query =>
-            lowerCaseAllowedResourceTypes.has(query.index.split('-')[0]),
+            lowerCaseAllowedResourceTypes.has(query.resourceType.toLowerCase()),
         );
 
-        const { hits } = await this.executeQueries(allowedInclusionQueries);
+        const { hits } = await this.executeQueries(allowedInclusionQueries, request);
         return this.hitsToSearchEntries({ hits, baseUrl, mode: 'include' });
     }
 
@@ -360,6 +419,7 @@ export class ElasticSearchService implements Search {
     // eslint-disable-next-line class-methods-use-this
     async globalSearch(request: GlobalSearchRequest): Promise<SearchResponse> {
         logger.info(request);
+        this.assertValidTenancyMode(request.tenantId);
         throw new Error('Method not implemented.');
     }
 


### PR DESCRIPTION
When multi-tenancy is enabled, a filter by `_tenantId` clause is added to ALL queries. Also queries use the tenant-specific alias.

Related PR: https://github.com/awslabs/fhir-works-on-aws-persistence-ddb/pull/91

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.