### PR TITLE
feat: handle searches against static ES mapping

### DIFF
--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - mainline
+      - v2.x.x
 jobs:
   unit-test:
     name: Unit Test and Linting

--- a/src/QueryBuilder/index.ts
+++ b/src/QueryBuilder/index.ts
@@ -17,7 +17,7 @@ function typeQueryWithConditions(
     searchParam: SearchParam,
     compiledSearchParam: CompiledSearchParam,
     searchValue: string,
-    isESStaticallyTyped: boolean,
+    useKeywordSubFields: boolean,
 ): any {
     let typeQuery: any;
     switch (searchParam.type) {
@@ -28,16 +28,16 @@ function typeQueryWithConditions(
             typeQuery = dateQuery(compiledSearchParam, searchValue);
             break;
         case 'token':
-            typeQuery = tokenQuery(compiledSearchParam, searchValue, isESStaticallyTyped);
+            typeQuery = tokenQuery(compiledSearchParam, searchValue, useKeywordSubFields);
             break;
         case 'number':
             typeQuery = numberQuery(compiledSearchParam, searchValue);
             break;
         case 'quantity':
-            typeQuery = quantityQuery(compiledSearchParam, searchValue, isESStaticallyTyped);
+            typeQuery = quantityQuery(compiledSearchParam, searchValue, useKeywordSubFields);
             break;
         case 'reference':
-            typeQuery = referenceQuery(compiledSearchParam, searchValue, isESStaticallyTyped);
+            typeQuery = referenceQuery(compiledSearchParam, searchValue, useKeywordSubFields);
             break;
         case 'composite':
         case 'special':
@@ -69,9 +69,9 @@ function typeQueryWithConditions(
     return typeQuery;
 }
 
-function searchParamQuery(searchParam: SearchParam, searchValue: string, isESStaticallyTyped: boolean): any {
+function searchParamQuery(searchParam: SearchParam, searchValue: string, useKeywordSubFields: boolean): any {
     const queries = searchParam.compiled.map(compiled => {
-        return typeQueryWithConditions(searchParam, compiled, searchValue, isESStaticallyTyped);
+        return typeQueryWithConditions(searchParam, compiled, searchValue, useKeywordSubFields);
     });
 
     if (queries.length === 1) {
@@ -108,7 +108,7 @@ function normalizeQueryParams(queryParams: any): { [key: string]: string[] } {
 function searchRequestQuery(
     fhirSearchParametersRegistry: FHIRSearchParametersRegistry,
     request: TypeSearchRequest,
-    isESStaticallyTyped: boolean,
+    useKeywordSubFields: boolean,
 ): any[] {
     const { queryParams, resourceType } = request;
     return Object.entries(normalizeQueryParams(queryParams))
@@ -120,7 +120,7 @@ function searchRequestQuery(
                     `Invalid search parameter '${searchParameter}' for resource type ${resourceType}`,
                 );
             }
-            return searchValues.map(searchValue => searchParamQuery(fhirSearchParam, searchValue, isESStaticallyTyped));
+            return searchValues.map(searchValue => searchParamQuery(fhirSearchParam, searchValue, useKeywordSubFields));
         });
 }
 
@@ -128,13 +128,13 @@ function searchRequestQuery(
 export const buildQueryForAllSearchParameters = (
     fhirSearchParametersRegistry: FHIRSearchParametersRegistry,
     request: TypeSearchRequest,
-    isESStaticallyTyped: boolean,
+    useKeywordSubFields: boolean,
     additionalFilters: any[] = [],
 ): any => {
     return {
         bool: {
             filter: additionalFilters,
-            must: searchRequestQuery(fhirSearchParametersRegistry, request, isESStaticallyTyped),
+            must: searchRequestQuery(fhirSearchParametersRegistry, request, useKeywordSubFields),
         },
     };
 };

--- a/src/QueryBuilder/typeQueries/quantityQuery.test.ts
+++ b/src/QueryBuilder/typeQueries/quantityQuery.test.ts
@@ -12,11 +12,9 @@ const fhirSearchParametersRegistry = new FHIRSearchParametersRegistry('4.0.1');
 const quantityParam = fhirSearchParametersRegistry.getSearchParameter('Observation', 'value-quantity')!.compiled[0];
 
 describe('quantityQuery', () => {
-    each([[true], [false]]).describe('valid inputs; isESStaticallyTyped=%j', async (isESStaticallyTyped: boolean) => {
-        const keywordSuffix = isESStaticallyTyped ? '' : '.keyword';
+    describe('valid inputs', () => {
         test('5.4|http://unitsofmeasure.org|mg', () => {
-            expect(quantityQuery(quantityParam, '5.4|http://unitsofmeasure.org|mg', isESStaticallyTyped))
-                .toMatchInlineSnapshot(`
+            expect(quantityQuery(quantityParam, '5.4|http://unitsofmeasure.org|mg', true)).toMatchInlineSnapshot(`
                 Object {
                   "bool": Object {
                     "must": Array [
@@ -31,7 +29,7 @@ describe('quantityQuery', () => {
                       Object {
                         "multi_match": Object {
                           "fields": Array [
-                            "valueQuantity.code${keywordSuffix}",
+                            "valueQuantity.code.keyword",
                           ],
                           "lenient": true,
                           "query": "mg",
@@ -40,7 +38,7 @@ describe('quantityQuery', () => {
                       Object {
                         "multi_match": Object {
                           "fields": Array [
-                            "valueQuantity.system${keywordSuffix}",
+                            "valueQuantity.system.keyword",
                           ],
                           "lenient": true,
                           "query": "http://unitsofmeasure.org",
@@ -52,8 +50,7 @@ describe('quantityQuery', () => {
             `);
         });
         test('5.40e-3|http://unitsofmeasure.org|g', () => {
-            expect(quantityQuery(quantityParam, '5.40e-3|http://unitsofmeasure.org|g', isESStaticallyTyped))
-                .toMatchInlineSnapshot(`
+            expect(quantityQuery(quantityParam, '5.40e-3|http://unitsofmeasure.org|g', true)).toMatchInlineSnapshot(`
                 Object {
                   "bool": Object {
                     "must": Array [
@@ -68,7 +65,7 @@ describe('quantityQuery', () => {
                       Object {
                         "multi_match": Object {
                           "fields": Array [
-                            "valueQuantity.code${keywordSuffix}",
+                            "valueQuantity.code.keyword",
                           ],
                           "lenient": true,
                           "query": "g",
@@ -77,7 +74,7 @@ describe('quantityQuery', () => {
                       Object {
                         "multi_match": Object {
                           "fields": Array [
-                            "valueQuantity.system${keywordSuffix}",
+                            "valueQuantity.system.keyword",
                           ],
                           "lenient": true,
                           "query": "http://unitsofmeasure.org",
@@ -89,7 +86,7 @@ describe('quantityQuery', () => {
             `);
         });
         test('5.4||mg', () => {
-            expect(quantityQuery(quantityParam, '5.4||mg', isESStaticallyTyped)).toMatchInlineSnapshot(`
+            expect(quantityQuery(quantityParam, '5.4||mg', true)).toMatchInlineSnapshot(`
                 Object {
                   "bool": Object {
                     "must": Array [
@@ -104,8 +101,8 @@ describe('quantityQuery', () => {
                       Object {
                         "multi_match": Object {
                           "fields": Array [
-                            "valueQuantity.code${keywordSuffix}",
-                            "valueQuantity.unit${keywordSuffix}",
+                            "valueQuantity.code.keyword",
+                            "valueQuantity.unit.keyword",
                           ],
                           "lenient": true,
                           "query": "mg",
@@ -117,7 +114,7 @@ describe('quantityQuery', () => {
             `);
         });
         test('5.4', () => {
-            expect(quantityQuery(quantityParam, '5.4', isESStaticallyTyped)).toMatchInlineSnapshot(`
+            expect(quantityQuery(quantityParam, '5.4', true)).toMatchInlineSnapshot(`
                 Object {
                   "range": Object {
                     "valueQuantity.value": Object {
@@ -129,8 +126,7 @@ describe('quantityQuery', () => {
             `);
         });
         test('le5.4|http://unitsofmeasure.org|mg', () => {
-            expect(quantityQuery(quantityParam, 'le5.4|http://unitsofmeasure.org|mg', isESStaticallyTyped))
-                .toMatchInlineSnapshot(`
+            expect(quantityQuery(quantityParam, 'le5.4|http://unitsofmeasure.org|mg', true)).toMatchInlineSnapshot(`
                 Object {
                   "bool": Object {
                     "must": Array [
@@ -144,7 +140,7 @@ describe('quantityQuery', () => {
                       Object {
                         "multi_match": Object {
                           "fields": Array [
-                            "valueQuantity.code${keywordSuffix}",
+                            "valueQuantity.code.keyword",
                           ],
                           "lenient": true,
                           "query": "mg",
@@ -153,7 +149,42 @@ describe('quantityQuery', () => {
                       Object {
                         "multi_match": Object {
                           "fields": Array [
-                            "valueQuantity.system${keywordSuffix}",
+                            "valueQuantity.system.keyword",
+                          ],
+                          "lenient": true,
+                          "query": "http://unitsofmeasure.org",
+                        },
+                      },
+                    ],
+                  },
+                }
+            `);
+        });
+        test('le5.4|http://unitsofmeasure.org|mg with no keyword', () => {
+            expect(quantityQuery(quantityParam, 'le5.4|http://unitsofmeasure.org|mg', false)).toMatchInlineSnapshot(`
+                Object {
+                  "bool": Object {
+                    "must": Array [
+                      Object {
+                        "range": Object {
+                          "valueQuantity.value": Object {
+                            "lte": 5.4,
+                          },
+                        },
+                      },
+                      Object {
+                        "multi_match": Object {
+                          "fields": Array [
+                            "valueQuantity.code",
+                          ],
+                          "lenient": true,
+                          "query": "mg",
+                        },
+                      },
+                      Object {
+                        "multi_match": Object {
+                          "fields": Array [
+                            "valueQuantity.system",
                           ],
                           "lenient": true,
                           "query": "http://unitsofmeasure.org",
@@ -175,7 +206,7 @@ describe('quantityQuery', () => {
             ['100xxx|system|code'],
             ['100e-2x|system|code'],
         ]).test('%s', param => {
-            expect(() => quantityQuery(quantityParam, param, false)).toThrow(InvalidSearchParameterError);
+            expect(() => quantityQuery(quantityParam, param, true)).toThrow(InvalidSearchParameterError);
         });
     });
 });

--- a/src/QueryBuilder/typeQueries/quantityQuery.test.ts
+++ b/src/QueryBuilder/typeQueries/quantityQuery.test.ts
@@ -12,9 +12,11 @@ const fhirSearchParametersRegistry = new FHIRSearchParametersRegistry('4.0.1');
 const quantityParam = fhirSearchParametersRegistry.getSearchParameter('Observation', 'value-quantity')!.compiled[0];
 
 describe('quantityQuery', () => {
-    describe('valid inputs', () => {
+    each([[true], [false]]).describe('valid inputs; isESStaticallyTyped=%j', async (isESStaticallyTyped: boolean) => {
+        const keywordSuffix = isESStaticallyTyped ? '' : '.keyword';
         test('5.4|http://unitsofmeasure.org|mg', () => {
-            expect(quantityQuery(quantityParam, '5.4|http://unitsofmeasure.org|mg')).toMatchInlineSnapshot(`
+            expect(quantityQuery(quantityParam, '5.4|http://unitsofmeasure.org|mg', isESStaticallyTyped))
+                .toMatchInlineSnapshot(`
                 Object {
                   "bool": Object {
                     "must": Array [
@@ -29,7 +31,7 @@ describe('quantityQuery', () => {
                       Object {
                         "multi_match": Object {
                           "fields": Array [
-                            "valueQuantity.code.keyword",
+                            "valueQuantity.code${keywordSuffix}",
                           ],
                           "lenient": true,
                           "query": "mg",
@@ -38,7 +40,7 @@ describe('quantityQuery', () => {
                       Object {
                         "multi_match": Object {
                           "fields": Array [
-                            "valueQuantity.system.keyword",
+                            "valueQuantity.system${keywordSuffix}",
                           ],
                           "lenient": true,
                           "query": "http://unitsofmeasure.org",
@@ -50,7 +52,8 @@ describe('quantityQuery', () => {
             `);
         });
         test('5.40e-3|http://unitsofmeasure.org|g', () => {
-            expect(quantityQuery(quantityParam, '5.40e-3|http://unitsofmeasure.org|g')).toMatchInlineSnapshot(`
+            expect(quantityQuery(quantityParam, '5.40e-3|http://unitsofmeasure.org|g', isESStaticallyTyped))
+                .toMatchInlineSnapshot(`
                 Object {
                   "bool": Object {
                     "must": Array [
@@ -65,7 +68,7 @@ describe('quantityQuery', () => {
                       Object {
                         "multi_match": Object {
                           "fields": Array [
-                            "valueQuantity.code.keyword",
+                            "valueQuantity.code${keywordSuffix}",
                           ],
                           "lenient": true,
                           "query": "g",
@@ -74,7 +77,7 @@ describe('quantityQuery', () => {
                       Object {
                         "multi_match": Object {
                           "fields": Array [
-                            "valueQuantity.system.keyword",
+                            "valueQuantity.system${keywordSuffix}",
                           ],
                           "lenient": true,
                           "query": "http://unitsofmeasure.org",
@@ -86,7 +89,7 @@ describe('quantityQuery', () => {
             `);
         });
         test('5.4||mg', () => {
-            expect(quantityQuery(quantityParam, '5.4||mg')).toMatchInlineSnapshot(`
+            expect(quantityQuery(quantityParam, '5.4||mg', isESStaticallyTyped)).toMatchInlineSnapshot(`
                 Object {
                   "bool": Object {
                     "must": Array [
@@ -101,8 +104,8 @@ describe('quantityQuery', () => {
                       Object {
                         "multi_match": Object {
                           "fields": Array [
-                            "valueQuantity.code.keyword",
-                            "valueQuantity.unit.keyword",
+                            "valueQuantity.code${keywordSuffix}",
+                            "valueQuantity.unit${keywordSuffix}",
                           ],
                           "lenient": true,
                           "query": "mg",
@@ -114,7 +117,7 @@ describe('quantityQuery', () => {
             `);
         });
         test('5.4', () => {
-            expect(quantityQuery(quantityParam, '5.4')).toMatchInlineSnapshot(`
+            expect(quantityQuery(quantityParam, '5.4', isESStaticallyTyped)).toMatchInlineSnapshot(`
                 Object {
                   "range": Object {
                     "valueQuantity.value": Object {
@@ -126,7 +129,8 @@ describe('quantityQuery', () => {
             `);
         });
         test('le5.4|http://unitsofmeasure.org|mg', () => {
-            expect(quantityQuery(quantityParam, 'le5.4|http://unitsofmeasure.org|mg')).toMatchInlineSnapshot(`
+            expect(quantityQuery(quantityParam, 'le5.4|http://unitsofmeasure.org|mg', isESStaticallyTyped))
+                .toMatchInlineSnapshot(`
                 Object {
                   "bool": Object {
                     "must": Array [
@@ -140,7 +144,7 @@ describe('quantityQuery', () => {
                       Object {
                         "multi_match": Object {
                           "fields": Array [
-                            "valueQuantity.code.keyword",
+                            "valueQuantity.code${keywordSuffix}",
                           ],
                           "lenient": true,
                           "query": "mg",
@@ -149,7 +153,7 @@ describe('quantityQuery', () => {
                       Object {
                         "multi_match": Object {
                           "fields": Array [
-                            "valueQuantity.system.keyword",
+                            "valueQuantity.system${keywordSuffix}",
                           ],
                           "lenient": true,
                           "query": "http://unitsofmeasure.org",
@@ -171,7 +175,7 @@ describe('quantityQuery', () => {
             ['100xxx|system|code'],
             ['100e-2x|system|code'],
         ]).test('%s', param => {
-            expect(() => quantityQuery(quantityParam, param)).toThrow(InvalidSearchParameterError);
+            expect(() => quantityQuery(quantityParam, param, false)).toThrow(InvalidSearchParameterError);
         });
     });
 });

--- a/src/QueryBuilder/typeQueries/quantityQuery.ts
+++ b/src/QueryBuilder/typeQueries/quantityQuery.ts
@@ -43,14 +43,19 @@ export const parseQuantitySearchParam = (param: string): QuantitySearchParameter
     };
 };
 
-export const quantityQuery = (compiledSearchParam: CompiledSearchParam, value: string): any => {
+export const quantityQuery = (
+    compiledSearchParam: CompiledSearchParam,
+    value: string,
+    isESStaticallyTyped: boolean,
+): any => {
     const { prefix, implicitRange, number, system, code } = parseQuantitySearchParam(value);
     const queries = [prefixRangeNumber(prefix, number, implicitRange, `${compiledSearchParam.path}.value`)];
+    const keywordSuffix = isESStaticallyTyped ? '' : '.keyword';
 
     if (!isEmpty(system) && !isEmpty(code)) {
         queries.push({
             multi_match: {
-                fields: [`${compiledSearchParam.path}.code.keyword`],
+                fields: [`${compiledSearchParam.path}.code${keywordSuffix}`],
                 query: code,
                 lenient: true,
             },
@@ -58,7 +63,7 @@ export const quantityQuery = (compiledSearchParam: CompiledSearchParam, value: s
 
         queries.push({
             multi_match: {
-                fields: [`${compiledSearchParam.path}.system.keyword`],
+                fields: [`${compiledSearchParam.path}.system${keywordSuffix}`],
                 query: system,
                 lenient: true,
             },
@@ -68,7 +73,10 @@ export const quantityQuery = (compiledSearchParam: CompiledSearchParam, value: s
         // https://www.hl7.org/fhir/search.html#quantity
         queries.push({
             multi_match: {
-                fields: [`${compiledSearchParam.path}.code.keyword`, `${compiledSearchParam.path}.unit.keyword`],
+                fields: [
+                    `${compiledSearchParam.path}.code${keywordSuffix}`,
+                    `${compiledSearchParam.path}.unit${keywordSuffix}`,
+                ],
                 query: code,
                 lenient: true,
             },

--- a/src/QueryBuilder/typeQueries/quantityQuery.ts
+++ b/src/QueryBuilder/typeQueries/quantityQuery.ts
@@ -46,11 +46,11 @@ export const parseQuantitySearchParam = (param: string): QuantitySearchParameter
 export const quantityQuery = (
     compiledSearchParam: CompiledSearchParam,
     value: string,
-    isESStaticallyTyped: boolean,
+    useKeywordSubFields: boolean,
 ): any => {
     const { prefix, implicitRange, number, system, code } = parseQuantitySearchParam(value);
     const queries = [prefixRangeNumber(prefix, number, implicitRange, `${compiledSearchParam.path}.value`)];
-    const keywordSuffix = isESStaticallyTyped ? '' : '.keyword';
+    const keywordSuffix = useKeywordSubFields ? '.keyword' : '';
 
     if (!isEmpty(system) && !isEmpty(code)) {
         queries.push({

--- a/src/QueryBuilder/typeQueries/referenceQuery.test.ts
+++ b/src/QueryBuilder/typeQueries/referenceQuery.test.ts
@@ -2,7 +2,7 @@
  *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  SPDX-License-Identifier: Apache-2.0
  */
-
+import each from 'jest-each';
 import { referenceQuery } from './referenceQuery';
 import { FHIRSearchParametersRegistry } from '../../FHIRSearchParametersRegistry';
 
@@ -10,12 +10,13 @@ const fhirSearchParametersRegistry = new FHIRSearchParametersRegistry('4.0.1');
 const organizationParam = fhirSearchParametersRegistry.getSearchParameter('Patient', 'organization')!.compiled[0];
 
 describe('referenceQuery', () => {
-    test('simple value', () => {
-        expect(referenceQuery(organizationParam, 'Organization/111')).toMatchInlineSnapshot(`
+    each([[true], [false]]).test('simple value; isESStaticallyTyped=%j', async (isESStaticallyTyped: boolean) => {
+        const keywordSuffix = isESStaticallyTyped ? '' : '.keyword';
+        expect(referenceQuery(organizationParam, 'Organization/111', isESStaticallyTyped)).toMatchInlineSnapshot(`
             Object {
               "multi_match": Object {
                 "fields": Array [
-                  "managingOrganization.reference.keyword",
+                  "managingOrganization.reference${keywordSuffix}",
                 ],
                 "lenient": true,
                 "query": "Organization/111",

--- a/src/QueryBuilder/typeQueries/referenceQuery.test.ts
+++ b/src/QueryBuilder/typeQueries/referenceQuery.test.ts
@@ -2,7 +2,7 @@
  *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  SPDX-License-Identifier: Apache-2.0
  */
-import each from 'jest-each';
+
 import { referenceQuery } from './referenceQuery';
 import { FHIRSearchParametersRegistry } from '../../FHIRSearchParametersRegistry';
 
@@ -10,13 +10,25 @@ const fhirSearchParametersRegistry = new FHIRSearchParametersRegistry('4.0.1');
 const organizationParam = fhirSearchParametersRegistry.getSearchParameter('Patient', 'organization')!.compiled[0];
 
 describe('referenceQuery', () => {
-    each([[true], [false]]).test('simple value; isESStaticallyTyped=%j', async (isESStaticallyTyped: boolean) => {
-        const keywordSuffix = isESStaticallyTyped ? '' : '.keyword';
-        expect(referenceQuery(organizationParam, 'Organization/111', isESStaticallyTyped)).toMatchInlineSnapshot(`
+    test('simple value; with keyword', () => {
+        expect(referenceQuery(organizationParam, 'Organization/111', true)).toMatchInlineSnapshot(`
             Object {
               "multi_match": Object {
                 "fields": Array [
-                  "managingOrganization.reference${keywordSuffix}",
+                  "managingOrganization.reference.keyword",
+                ],
+                "lenient": true,
+                "query": "Organization/111",
+              },
+            }
+        `);
+    });
+    test('simple value; without keyword', () => {
+        expect(referenceQuery(organizationParam, 'Organization/111', false)).toMatchInlineSnapshot(`
+            Object {
+              "multi_match": Object {
+                "fields": Array [
+                  "managingOrganization.reference",
                 ],
                 "lenient": true,
                 "query": "Organization/111",

--- a/src/QueryBuilder/typeQueries/referenceQuery.ts
+++ b/src/QueryBuilder/typeQueries/referenceQuery.ts
@@ -6,8 +6,10 @@
 import { CompiledSearchParam } from '../../FHIRSearchParametersRegistry';
 
 // eslint-disable-next-line import/prefer-default-export
-export function referenceQuery(compiled: CompiledSearchParam, value: string): any {
-    const fields = [`${compiled.path}.reference.keyword`];
+export function referenceQuery(compiled: CompiledSearchParam, value: string, isESStaticallyTyped: boolean): any {
+    const keywordSuffix = isESStaticallyTyped ? '' : '.keyword';
+
+    const fields = [`${compiled.path}.reference${keywordSuffix}`];
     return {
         multi_match: {
             fields,

--- a/src/QueryBuilder/typeQueries/referenceQuery.ts
+++ b/src/QueryBuilder/typeQueries/referenceQuery.ts
@@ -6,8 +6,8 @@
 import { CompiledSearchParam } from '../../FHIRSearchParametersRegistry';
 
 // eslint-disable-next-line import/prefer-default-export
-export function referenceQuery(compiled: CompiledSearchParam, value: string, isESStaticallyTyped: boolean): any {
-    const keywordSuffix = isESStaticallyTyped ? '' : '.keyword';
+export function referenceQuery(compiled: CompiledSearchParam, value: string, useKeywordSubFields: boolean): any {
+    const keywordSuffix = useKeywordSubFields ? '.keyword' : '';
 
     const fields = [`${compiled.path}.reference${keywordSuffix}`];
     return {

--- a/src/QueryBuilder/typeQueries/tokenQuery.test.ts
+++ b/src/QueryBuilder/typeQueries/tokenQuery.test.ts
@@ -2,7 +2,7 @@
  *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  SPDX-License-Identifier: Apache-2.0
  */
-import each from 'jest-each';
+
 import { InvalidSearchParameterError } from 'fhir-works-on-aws-interface';
 import { parseTokenSearchParam, tokenQuery } from './tokenQuery';
 import { FHIRSearchParametersRegistry } from '../../FHIRSearchParametersRegistry';
@@ -80,17 +80,16 @@ describe('parseTokenSearchParam', () => {
 });
 
 describe('tokenQuery', () => {
-    each([[true], [false]]).test('system|code; isESStaticallyTyped=%j', async (isESStaticallyTyped: boolean) => {
-        const keywordSuffix = isESStaticallyTyped ? '' : '.keyword';
-        expect(tokenQuery(identifierParam, 'http://acme.org/patient|2345', isESStaticallyTyped)).toMatchInlineSnapshot(`
+    test('system|code', () => {
+        expect(tokenQuery(identifierParam, 'http://acme.org/patient|2345', true)).toMatchInlineSnapshot(`
             Object {
               "bool": Object {
                 "must": Array [
                   Object {
                     "multi_match": Object {
                       "fields": Array [
-                        "identifier.system${keywordSuffix}",
-                        "identifier.coding.system${keywordSuffix}",
+                        "identifier.system.keyword",
+                        "identifier.coding.system.keyword",
                       ],
                       "lenient": true,
                       "query": "http://acme.org/patient",
@@ -99,9 +98,9 @@ describe('tokenQuery', () => {
                   Object {
                     "multi_match": Object {
                       "fields": Array [
-                        "identifier.code${keywordSuffix}",
-                        "identifier.coding.code${keywordSuffix}",
-                        "identifier.value${keywordSuffix}",
+                        "identifier.code.keyword",
+                        "identifier.coding.code.keyword",
+                        "identifier.value.keyword",
                         "identifier",
                       ],
                       "lenient": true,
@@ -113,15 +112,14 @@ describe('tokenQuery', () => {
             }
         `);
     });
-    each([[true], [false]]).test('system|; isESStaticallyTyped=%j', async (isESStaticallyTyped: boolean) => {
-        const keywordSuffix = isESStaticallyTyped ? '' : '.keyword';
-        expect(tokenQuery(identifierParam, 'http://acme.org/patient', isESStaticallyTyped)).toMatchInlineSnapshot(`
+    test('system|', () => {
+        expect(tokenQuery(identifierParam, 'http://acme.org/patient', true)).toMatchInlineSnapshot(`
             Object {
               "multi_match": Object {
                 "fields": Array [
-                  "identifier.code${keywordSuffix}",
-                  "identifier.coding.code${keywordSuffix}",
-                  "identifier.value${keywordSuffix}",
+                  "identifier.code.keyword",
+                  "identifier.coding.code.keyword",
+                  "identifier.value.keyword",
                   "identifier",
                 ],
                 "lenient": true,
@@ -130,18 +128,17 @@ describe('tokenQuery', () => {
             }
         `);
     });
-    each([[true], [false]]).test('|code; isESStaticallyTyped=%j', async (isESStaticallyTyped: boolean) => {
-        const keywordSuffix = isESStaticallyTyped ? '' : '.keyword';
-        expect(tokenQuery(identifierParam, '|2345', isESStaticallyTyped)).toMatchInlineSnapshot(`
+    test('|code', () => {
+        expect(tokenQuery(identifierParam, '|2345', true)).toMatchInlineSnapshot(`
             Object {
               "bool": Object {
                 "must": Array [
                   Object {
                     "multi_match": Object {
                       "fields": Array [
-                        "identifier.code${keywordSuffix}",
-                        "identifier.coding.code${keywordSuffix}",
-                        "identifier.value${keywordSuffix}",
+                        "identifier.code.keyword",
+                        "identifier.coding.code.keyword",
+                        "identifier.value.keyword",
                         "identifier",
                       ],
                       "lenient": true,
@@ -162,17 +159,16 @@ describe('tokenQuery', () => {
             }
         `);
     });
-    each([[true], [false]]).test('code; isESStaticallyTyped=%j', async (isESStaticallyTyped: boolean) => {
-        const keywordSuffix = isESStaticallyTyped ? '' : '.keyword';
-        expect(tokenQuery(identifierParam, 'http://acme.org/patient|2345', isESStaticallyTyped)).toMatchInlineSnapshot(`
+    test('code', () => {
+        expect(tokenQuery(identifierParam, 'http://acme.org/patient|2345', true)).toMatchInlineSnapshot(`
             Object {
               "bool": Object {
                 "must": Array [
                   Object {
                     "multi_match": Object {
                       "fields": Array [
-                        "identifier.system${keywordSuffix}",
-                        "identifier.coding.system${keywordSuffix}",
+                        "identifier.system.keyword",
+                        "identifier.coding.system.keyword",
                       ],
                       "lenient": true,
                       "query": "http://acme.org/patient",
@@ -181,9 +177,41 @@ describe('tokenQuery', () => {
                   Object {
                     "multi_match": Object {
                       "fields": Array [
-                        "identifier.code${keywordSuffix}",
-                        "identifier.coding.code${keywordSuffix}",
-                        "identifier.value${keywordSuffix}",
+                        "identifier.code.keyword",
+                        "identifier.coding.code.keyword",
+                        "identifier.value.keyword",
+                        "identifier",
+                      ],
+                      "lenient": true,
+                      "query": "2345",
+                    },
+                  },
+                ],
+              },
+            }
+        `);
+    });
+    test('code; without keyword', () => {
+        expect(tokenQuery(identifierParam, 'http://acme.org/patient|2345', false)).toMatchInlineSnapshot(`
+            Object {
+              "bool": Object {
+                "must": Array [
+                  Object {
+                    "multi_match": Object {
+                      "fields": Array [
+                        "identifier.system",
+                        "identifier.coding.system",
+                      ],
+                      "lenient": true,
+                      "query": "http://acme.org/patient",
+                    },
+                  },
+                  Object {
+                    "multi_match": Object {
+                      "fields": Array [
+                        "identifier.code",
+                        "identifier.coding.code",
+                        "identifier.value",
                         "identifier",
                       ],
                       "lenient": true,

--- a/src/QueryBuilder/typeQueries/tokenQuery.test.ts
+++ b/src/QueryBuilder/typeQueries/tokenQuery.test.ts
@@ -2,7 +2,7 @@
  *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  SPDX-License-Identifier: Apache-2.0
  */
-
+import each from 'jest-each';
 import { InvalidSearchParameterError } from 'fhir-works-on-aws-interface';
 import { parseTokenSearchParam, tokenQuery } from './tokenQuery';
 import { FHIRSearchParametersRegistry } from '../../FHIRSearchParametersRegistry';
@@ -80,16 +80,17 @@ describe('parseTokenSearchParam', () => {
 });
 
 describe('tokenQuery', () => {
-    test('system|code', () => {
-        expect(tokenQuery(identifierParam, 'http://acme.org/patient|2345')).toMatchInlineSnapshot(`
+    each([[true], [false]]).test('system|code; isESStaticallyTyped=%j', async (isESStaticallyTyped: boolean) => {
+        const keywordSuffix = isESStaticallyTyped ? '' : '.keyword';
+        expect(tokenQuery(identifierParam, 'http://acme.org/patient|2345', isESStaticallyTyped)).toMatchInlineSnapshot(`
             Object {
               "bool": Object {
                 "must": Array [
                   Object {
                     "multi_match": Object {
                       "fields": Array [
-                        "identifier.system.keyword",
-                        "identifier.coding.system.keyword",
+                        "identifier.system${keywordSuffix}",
+                        "identifier.coding.system${keywordSuffix}",
                       ],
                       "lenient": true,
                       "query": "http://acme.org/patient",
@@ -98,9 +99,9 @@ describe('tokenQuery', () => {
                   Object {
                     "multi_match": Object {
                       "fields": Array [
-                        "identifier.code.keyword",
-                        "identifier.coding.code.keyword",
-                        "identifier.value.keyword",
+                        "identifier.code${keywordSuffix}",
+                        "identifier.coding.code${keywordSuffix}",
+                        "identifier.value${keywordSuffix}",
                         "identifier",
                       ],
                       "lenient": true,
@@ -112,14 +113,15 @@ describe('tokenQuery', () => {
             }
         `);
     });
-    test('system|', () => {
-        expect(tokenQuery(identifierParam, 'http://acme.org/patient')).toMatchInlineSnapshot(`
+    each([[true], [false]]).test('system|; isESStaticallyTyped=%j', async (isESStaticallyTyped: boolean) => {
+        const keywordSuffix = isESStaticallyTyped ? '' : '.keyword';
+        expect(tokenQuery(identifierParam, 'http://acme.org/patient', isESStaticallyTyped)).toMatchInlineSnapshot(`
             Object {
               "multi_match": Object {
                 "fields": Array [
-                  "identifier.code.keyword",
-                  "identifier.coding.code.keyword",
-                  "identifier.value.keyword",
+                  "identifier.code${keywordSuffix}",
+                  "identifier.coding.code${keywordSuffix}",
+                  "identifier.value${keywordSuffix}",
                   "identifier",
                 ],
                 "lenient": true,
@@ -128,17 +130,18 @@ describe('tokenQuery', () => {
             }
         `);
     });
-    test('|code', () => {
-        expect(tokenQuery(identifierParam, '|2345')).toMatchInlineSnapshot(`
+    each([[true], [false]]).test('|code; isESStaticallyTyped=%j', async (isESStaticallyTyped: boolean) => {
+        const keywordSuffix = isESStaticallyTyped ? '' : '.keyword';
+        expect(tokenQuery(identifierParam, '|2345', isESStaticallyTyped)).toMatchInlineSnapshot(`
             Object {
               "bool": Object {
                 "must": Array [
                   Object {
                     "multi_match": Object {
                       "fields": Array [
-                        "identifier.code.keyword",
-                        "identifier.coding.code.keyword",
-                        "identifier.value.keyword",
+                        "identifier.code${keywordSuffix}",
+                        "identifier.coding.code${keywordSuffix}",
+                        "identifier.value${keywordSuffix}",
                         "identifier",
                       ],
                       "lenient": true,
@@ -159,16 +162,17 @@ describe('tokenQuery', () => {
             }
         `);
     });
-    test('code', () => {
-        expect(tokenQuery(identifierParam, 'http://acme.org/patient|2345')).toMatchInlineSnapshot(`
+    each([[true], [false]]).test('code; isESStaticallyTyped=%j', async (isESStaticallyTyped: boolean) => {
+        const keywordSuffix = isESStaticallyTyped ? '' : '.keyword';
+        expect(tokenQuery(identifierParam, 'http://acme.org/patient|2345', isESStaticallyTyped)).toMatchInlineSnapshot(`
             Object {
               "bool": Object {
                 "must": Array [
                   Object {
                     "multi_match": Object {
                       "fields": Array [
-                        "identifier.system.keyword",
-                        "identifier.coding.system.keyword",
+                        "identifier.system${keywordSuffix}",
+                        "identifier.coding.system${keywordSuffix}",
                       ],
                       "lenient": true,
                       "query": "http://acme.org/patient",
@@ -177,9 +181,9 @@ describe('tokenQuery', () => {
                   Object {
                     "multi_match": Object {
                       "fields": Array [
-                        "identifier.code.keyword",
-                        "identifier.coding.code.keyword",
-                        "identifier.value.keyword",
+                        "identifier.code${keywordSuffix}",
+                        "identifier.coding.code${keywordSuffix}",
+                        "identifier.value${keywordSuffix}",
                         "identifier",
                       ],
                       "lenient": true,

--- a/src/QueryBuilder/typeQueries/tokenQuery.ts
+++ b/src/QueryBuilder/typeQueries/tokenQuery.ts
@@ -39,10 +39,10 @@ export const parseTokenSearchParam = (param: string): TokenSearchParameter => {
     return { system, code, explicitNoSystemProperty };
 };
 
-export function tokenQuery(compiled: CompiledSearchParam, value: string, isESStaticallyTyped: boolean): any {
+export function tokenQuery(compiled: CompiledSearchParam, value: string, useKeywordSubFields: boolean): any {
     const { system, code, explicitNoSystemProperty } = parseTokenSearchParam(value);
     const queries = [];
-    const keywordSuffix = isESStaticallyTyped ? '' : '.keyword';
+    const keywordSuffix = useKeywordSubFields ? '.keyword' : '';
 
     // Token search params are used for many different field types. Search is not aware of the types of the fields in FHIR resources.
     // The field type is specified in StructureDefinition, but not in SearchParameter.

--- a/src/QueryBuilder/typeQueries/tokenQuery.ts
+++ b/src/QueryBuilder/typeQueries/tokenQuery.ts
@@ -39,9 +39,10 @@ export const parseTokenSearchParam = (param: string): TokenSearchParameter => {
     return { system, code, explicitNoSystemProperty };
 };
 
-export function tokenQuery(compiled: CompiledSearchParam, value: string): any {
+export function tokenQuery(compiled: CompiledSearchParam, value: string, isESStaticallyTyped: boolean): any {
     const { system, code, explicitNoSystemProperty } = parseTokenSearchParam(value);
     const queries = [];
+    const keywordSuffix = isESStaticallyTyped ? '' : '.keyword';
 
     // Token search params are used for many different field types. Search is not aware of the types of the fields in FHIR resources.
     // The field type is specified in StructureDefinition, but not in SearchParameter.
@@ -50,8 +51,8 @@ export function tokenQuery(compiled: CompiledSearchParam, value: string): any {
     // See: https://www.hl7.org/fhir/search.html#token
     if (system !== undefined) {
         const fields = [
-            `${compiled.path}.system.keyword`, // Coding, Identifier
-            `${compiled.path}.coding.system.keyword`, // CodeableConcept
+            `${compiled.path}.system${keywordSuffix}`, // Coding, Identifier
+            `${compiled.path}.coding.system${keywordSuffix}`, // CodeableConcept
         ];
 
         queries.push({
@@ -65,9 +66,9 @@ export function tokenQuery(compiled: CompiledSearchParam, value: string): any {
 
     if (code !== undefined) {
         const fields = [
-            `${compiled.path}.code.keyword`, // Coding
-            `${compiled.path}.coding.code.keyword`, // CodeableConcept
-            `${compiled.path}.value.keyword`, // Identifier, ContactPoint
+            `${compiled.path}.code${keywordSuffix}`, // Coding
+            `${compiled.path}.coding.code${keywordSuffix}`, // CodeableConcept
+            `${compiled.path}.value${keywordSuffix}`, // Identifier, ContactPoint
             `${compiled.path}`, // code, boolean, uri, string
         ];
 

--- a/src/elasticSearchService.ts
+++ b/src/elasticSearchService.ts
@@ -61,7 +61,7 @@ export class ElasticSearchService implements Search {
      * @param compiledImplementationGuides - The output of ImplementationGuides.compile.
      * This parameter enables support for search parameters defined in Implementation Guides.
      * @param esClient
-     * @param options.useKeywordSubFields - whether or not you would want `.keyword` is appended to specifc search fields or not. You should use iff you do dynamic mapping
+     * @param options.useKeywordSubFields - whether or not to append `.keyword` to fields in search queries. You should enable this if you do dynamic mapping
      */
     constructor(
         searchFiltersForAllQueries: SearchFilter[] = [],

--- a/src/elasticSearchService.ts
+++ b/src/elasticSearchService.ts
@@ -49,7 +49,7 @@ export class ElasticSearchService implements Search {
 
     private readonly fhirSearchParametersRegistry: FHIRSearchParametersRegistry;
 
-    private readonly isESStaticallyTyped: boolean;
+    private readonly useKeywordSubFields: boolean;
 
     /**
      * @param searchFiltersForAllQueries - If you are storing both History and Search resources
@@ -61,7 +61,7 @@ export class ElasticSearchService implements Search {
      * @param compiledImplementationGuides - The output of ImplementationGuides.compile.
      * This parameter enables support for search parameters defined in Implementation Guides.
      * @param esClient
-     * @param options.isESStaticallyTyped - whether or not your ES cluster has been statically typed. This effects if a `.keyword` is appended to search fields or not
+     * @param options.useKeywordSubFields - whether or not you would want `.keyword` is appended to specifc search fields or not. You should use iff you do dynamic mapping
      */
     constructor(
         searchFiltersForAllQueries: SearchFilter[] = [],
@@ -71,14 +71,14 @@ export class ElasticSearchService implements Search {
         fhirVersion: FhirVersion = '4.0.1',
         compiledImplementationGuides?: any,
         esClient: Client = ElasticSearch,
-        { isESStaticallyTyped = false }: { isESStaticallyTyped?: boolean } = {},
+        { useKeywordSubFields = true }: { useKeywordSubFields?: boolean } = {},
     ) {
         this.searchFiltersForAllQueries = searchFiltersForAllQueries;
         this.cleanUpFunction = cleanUpFunction;
         this.fhirVersion = fhirVersion;
         this.fhirSearchParametersRegistry = new FHIRSearchParametersRegistry(fhirVersion, compiledImplementationGuides);
         this.esClient = esClient;
-        this.isESStaticallyTyped = isESStaticallyTyped;
+        this.useKeywordSubFields = useKeywordSubFields;
     }
 
     async getCapabilities() {
@@ -116,7 +116,7 @@ export class ElasticSearchService implements Search {
             const query = buildQueryForAllSearchParameters(
                 this.fhirSearchParametersRegistry,
                 request,
-                this.isESStaticallyTyped,
+                this.useKeywordSubFields,
                 filter,
             );
 
@@ -296,7 +296,7 @@ export class ElasticSearchService implements Search {
             searchEntries.map(x => x.resource),
             filter,
             this.fhirSearchParametersRegistry,
-            this.isESStaticallyTyped,
+            this.useKeywordSubFields,
             iterative,
         );
 

--- a/src/searchInclusions.ts
+++ b/src/searchInclusions.ts
@@ -195,9 +195,9 @@ export const buildRevIncludeQuery = (
     revIncludeSearchParameter: InclusionSearchParameter,
     references: string[],
     filterRulesForActiveResources: any[],
-    isESStaticallyTyped: boolean,
+    useKeywordSubFields: boolean,
 ) => {
-    const keywordSuffix = isESStaticallyTyped ? '' : '.keyword';
+    const keywordSuffix = useKeywordSubFields ? 'keyword' : '';
 
     const { sourceResource, path } = revIncludeSearchParameter;
     return {
@@ -286,7 +286,7 @@ export const buildRevIncludeQueries = (
     resources: any[],
     filterRulesForActiveResources: any[],
     fhirSearchParametersRegistry: FHIRSearchParametersRegistry,
-    isESStaticallyTyped: boolean,
+    useKeywordSubFields: boolean,
     iterate?: true,
 ) => {
     const allRevincludeParameters = getInclusionParametersFromQueryParams('_revinclude', queryParams, iterate);
@@ -306,7 +306,7 @@ export const buildRevIncludeQueries = (
     const revincludeReferences = getRevincludeReferencesFromResources(revIncludeParameters, resources);
 
     const searchQueries = revincludeReferences.map(({ revinclude, references }) =>
-        buildRevIncludeQuery(revinclude, references, filterRulesForActiveResources, isESStaticallyTyped),
+        buildRevIncludeQuery(revinclude, references, filterRulesForActiveResources, useKeywordSubFields),
     );
     return searchQueries;
 };

--- a/src/searchInclusions.ts
+++ b/src/searchInclusions.ts
@@ -195,7 +195,10 @@ export const buildRevIncludeQuery = (
     revIncludeSearchParameter: InclusionSearchParameter,
     references: string[],
     filterRulesForActiveResources: any[],
+    isESStaticallyTyped: boolean,
 ) => {
+    const keywordSuffix = isESStaticallyTyped ? '' : '.keyword';
+
     const { sourceResource, path } = revIncludeSearchParameter;
     return {
         index: sourceResource.toLowerCase(),
@@ -205,7 +208,7 @@ export const buildRevIncludeQuery = (
                     filter: [
                         {
                             terms: {
-                                [`${path}.reference.keyword`]: references,
+                                [`${path}.reference${keywordSuffix}`]: references,
                             },
                         },
                         ...filterRulesForActiveResources,
@@ -283,6 +286,7 @@ export const buildRevIncludeQueries = (
     resources: any[],
     filterRulesForActiveResources: any[],
     fhirSearchParametersRegistry: FHIRSearchParametersRegistry,
+    isESStaticallyTyped: boolean,
     iterate?: true,
 ) => {
     const allRevincludeParameters = getInclusionParametersFromQueryParams('_revinclude', queryParams, iterate);
@@ -302,7 +306,7 @@ export const buildRevIncludeQueries = (
     const revincludeReferences = getRevincludeReferencesFromResources(revIncludeParameters, resources);
 
     const searchQueries = revincludeReferences.map(({ revinclude, references }) =>
-        buildRevIncludeQuery(revinclude, references, filterRulesForActiveResources),
+        buildRevIncludeQuery(revinclude, references, filterRulesForActiveResources, isESStaticallyTyped),
     );
     return searchQueries;
 };

--- a/src/searchInclusions.ts
+++ b/src/searchInclusions.ts
@@ -197,7 +197,7 @@ export const buildRevIncludeQuery = (
     filterRulesForActiveResources: any[],
     useKeywordSubFields: boolean,
 ) => {
-    const keywordSuffix = useKeywordSubFields ? 'keyword' : '';
+    const keywordSuffix = useKeywordSubFields ? '.keyword' : '';
 
     const { sourceResource, path } = revIncludeSearchParameter;
     return {


### PR DESCRIPTION
Description of changes:
- Adding new constructor parameter to pass-in if customer is using static mapping or not
  - if `true` `.keyword` will be added to the restricted search queries


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.