### PR TITLE
feat: Add flexibility to searches against static ES mapping

### DIFF
--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - mainline
+      - v2.x.x
 jobs:
   unit-test:
     name: Unit Test and Linting

--- a/src/QueryBuilder/index.ts
+++ b/src/QueryBuilder/index.ts
@@ -17,6 +17,7 @@ function typeQueryWithConditions(
     searchParam: SearchParam,
     compiledSearchParam: CompiledSearchParam,
     searchValue: string,
+    useKeywordSubFields: boolean,
 ): any {
     let typeQuery: any;
     switch (searchParam.type) {
@@ -27,16 +28,16 @@ function typeQueryWithConditions(
             typeQuery = dateQuery(compiledSearchParam, searchValue);
             break;
         case 'token':
-            typeQuery = tokenQuery(compiledSearchParam, searchValue);
+            typeQuery = tokenQuery(compiledSearchParam, searchValue, useKeywordSubFields);
             break;
         case 'number':
             typeQuery = numberQuery(compiledSearchParam, searchValue);
             break;
         case 'quantity':
-            typeQuery = quantityQuery(compiledSearchParam, searchValue);
+            typeQuery = quantityQuery(compiledSearchParam, searchValue, useKeywordSubFields);
             break;
         case 'reference':
-            typeQuery = referenceQuery(compiledSearchParam, searchValue);
+            typeQuery = referenceQuery(compiledSearchParam, searchValue, useKeywordSubFields);
             break;
         case 'composite':
         case 'special':
@@ -68,9 +69,9 @@ function typeQueryWithConditions(
     return typeQuery;
 }
 
-function searchParamQuery(searchParam: SearchParam, searchValue: string): any {
+function searchParamQuery(searchParam: SearchParam, searchValue: string, useKeywordSubFields: boolean): any {
     const queries = searchParam.compiled.map(compiled => {
-        return typeQueryWithConditions(searchParam, compiled, searchValue);
+        return typeQueryWithConditions(searchParam, compiled, searchValue, useKeywordSubFields);
     });
 
     if (queries.length === 1) {
@@ -107,6 +108,7 @@ function normalizeQueryParams(queryParams: any): { [key: string]: string[] } {
 function searchRequestQuery(
     fhirSearchParametersRegistry: FHIRSearchParametersRegistry,
     request: TypeSearchRequest,
+    useKeywordSubFields: boolean,
 ): any[] {
     const { queryParams, resourceType } = request;
     return Object.entries(normalizeQueryParams(queryParams))
@@ -118,7 +120,7 @@ function searchRequestQuery(
                     `Invalid search parameter '${searchParameter}' for resource type ${resourceType}`,
                 );
             }
-            return searchValues.map(searchValue => searchParamQuery(fhirSearchParam, searchValue));
+            return searchValues.map(searchValue => searchParamQuery(fhirSearchParam, searchValue, useKeywordSubFields));
         });
 }
 
@@ -126,12 +128,13 @@ function searchRequestQuery(
 export const buildQueryForAllSearchParameters = (
     fhirSearchParametersRegistry: FHIRSearchParametersRegistry,
     request: TypeSearchRequest,
+    useKeywordSubFields: boolean,
     additionalFilters: any[] = [],
 ): any => {
     return {
         bool: {
             filter: additionalFilters,
-            must: searchRequestQuery(fhirSearchParametersRegistry, request),
+            must: searchRequestQuery(fhirSearchParametersRegistry, request, useKeywordSubFields),
         },
     };
 };

--- a/src/QueryBuilder/typeQueries/quantityQuery.test.ts
+++ b/src/QueryBuilder/typeQueries/quantityQuery.test.ts
@@ -14,7 +14,7 @@ const quantityParam = fhirSearchParametersRegistry.getSearchParameter('Observati
 describe('quantityQuery', () => {
     describe('valid inputs', () => {
         test('5.4|http://unitsofmeasure.org|mg', () => {
-            expect(quantityQuery(quantityParam, '5.4|http://unitsofmeasure.org|mg')).toMatchInlineSnapshot(`
+            expect(quantityQuery(quantityParam, '5.4|http://unitsofmeasure.org|mg', true)).toMatchInlineSnapshot(`
                 Object {
                   "bool": Object {
                     "must": Array [
@@ -50,7 +50,7 @@ describe('quantityQuery', () => {
             `);
         });
         test('5.40e-3|http://unitsofmeasure.org|g', () => {
-            expect(quantityQuery(quantityParam, '5.40e-3|http://unitsofmeasure.org|g')).toMatchInlineSnapshot(`
+            expect(quantityQuery(quantityParam, '5.40e-3|http://unitsofmeasure.org|g', true)).toMatchInlineSnapshot(`
                 Object {
                   "bool": Object {
                     "must": Array [
@@ -86,7 +86,7 @@ describe('quantityQuery', () => {
             `);
         });
         test('5.4||mg', () => {
-            expect(quantityQuery(quantityParam, '5.4||mg')).toMatchInlineSnapshot(`
+            expect(quantityQuery(quantityParam, '5.4||mg', true)).toMatchInlineSnapshot(`
                 Object {
                   "bool": Object {
                     "must": Array [
@@ -114,7 +114,7 @@ describe('quantityQuery', () => {
             `);
         });
         test('5.4', () => {
-            expect(quantityQuery(quantityParam, '5.4')).toMatchInlineSnapshot(`
+            expect(quantityQuery(quantityParam, '5.4', true)).toMatchInlineSnapshot(`
                 Object {
                   "range": Object {
                     "valueQuantity.value": Object {
@@ -126,7 +126,7 @@ describe('quantityQuery', () => {
             `);
         });
         test('le5.4|http://unitsofmeasure.org|mg', () => {
-            expect(quantityQuery(quantityParam, 'le5.4|http://unitsofmeasure.org|mg')).toMatchInlineSnapshot(`
+            expect(quantityQuery(quantityParam, 'le5.4|http://unitsofmeasure.org|mg', true)).toMatchInlineSnapshot(`
                 Object {
                   "bool": Object {
                     "must": Array [
@@ -160,6 +160,41 @@ describe('quantityQuery', () => {
                 }
             `);
         });
+        test('le5.4|http://unitsofmeasure.org|mg with no keyword', () => {
+            expect(quantityQuery(quantityParam, 'le5.4|http://unitsofmeasure.org|mg', false)).toMatchInlineSnapshot(`
+                Object {
+                  "bool": Object {
+                    "must": Array [
+                      Object {
+                        "range": Object {
+                          "valueQuantity.value": Object {
+                            "lte": 5.4,
+                          },
+                        },
+                      },
+                      Object {
+                        "multi_match": Object {
+                          "fields": Array [
+                            "valueQuantity.code",
+                          ],
+                          "lenient": true,
+                          "query": "mg",
+                        },
+                      },
+                      Object {
+                        "multi_match": Object {
+                          "fields": Array [
+                            "valueQuantity.system",
+                          ],
+                          "lenient": true,
+                          "query": "http://unitsofmeasure.org",
+                        },
+                      },
+                    ],
+                  },
+                }
+            `);
+        });
     });
 
     describe('invalid inputs', () => {
@@ -171,7 +206,7 @@ describe('quantityQuery', () => {
             ['100xxx|system|code'],
             ['100e-2x|system|code'],
         ]).test('%s', param => {
-            expect(() => quantityQuery(quantityParam, param)).toThrow(InvalidSearchParameterError);
+            expect(() => quantityQuery(quantityParam, param, true)).toThrow(InvalidSearchParameterError);
         });
     });
 });

--- a/src/QueryBuilder/typeQueries/quantityQuery.ts
+++ b/src/QueryBuilder/typeQueries/quantityQuery.ts
@@ -43,14 +43,19 @@ export const parseQuantitySearchParam = (param: string): QuantitySearchParameter
     };
 };
 
-export const quantityQuery = (compiledSearchParam: CompiledSearchParam, value: string): any => {
+export const quantityQuery = (
+    compiledSearchParam: CompiledSearchParam,
+    value: string,
+    useKeywordSubFields: boolean,
+): any => {
     const { prefix, implicitRange, number, system, code } = parseQuantitySearchParam(value);
     const queries = [prefixRangeNumber(prefix, number, implicitRange, `${compiledSearchParam.path}.value`)];
+    const keywordSuffix = useKeywordSubFields ? '.keyword' : '';
 
     if (!isEmpty(system) && !isEmpty(code)) {
         queries.push({
             multi_match: {
-                fields: [`${compiledSearchParam.path}.code.keyword`],
+                fields: [`${compiledSearchParam.path}.code${keywordSuffix}`],
                 query: code,
                 lenient: true,
             },
@@ -58,7 +63,7 @@ export const quantityQuery = (compiledSearchParam: CompiledSearchParam, value: s
 
         queries.push({
             multi_match: {
-                fields: [`${compiledSearchParam.path}.system.keyword`],
+                fields: [`${compiledSearchParam.path}.system${keywordSuffix}`],
                 query: system,
                 lenient: true,
             },
@@ -68,7 +73,10 @@ export const quantityQuery = (compiledSearchParam: CompiledSearchParam, value: s
         // https://www.hl7.org/fhir/search.html#quantity
         queries.push({
             multi_match: {
-                fields: [`${compiledSearchParam.path}.code.keyword`, `${compiledSearchParam.path}.unit.keyword`],
+                fields: [
+                    `${compiledSearchParam.path}.code${keywordSuffix}`,
+                    `${compiledSearchParam.path}.unit${keywordSuffix}`,
+                ],
                 query: code,
                 lenient: true,
             },

--- a/src/QueryBuilder/typeQueries/referenceQuery.test.ts
+++ b/src/QueryBuilder/typeQueries/referenceQuery.test.ts
@@ -10,12 +10,25 @@ const fhirSearchParametersRegistry = new FHIRSearchParametersRegistry('4.0.1');
 const organizationParam = fhirSearchParametersRegistry.getSearchParameter('Patient', 'organization')!.compiled[0];
 
 describe('referenceQuery', () => {
-    test('simple value', () => {
-        expect(referenceQuery(organizationParam, 'Organization/111')).toMatchInlineSnapshot(`
+    test('simple value; with keyword', () => {
+        expect(referenceQuery(organizationParam, 'Organization/111', true)).toMatchInlineSnapshot(`
             Object {
               "multi_match": Object {
                 "fields": Array [
                   "managingOrganization.reference.keyword",
+                ],
+                "lenient": true,
+                "query": "Organization/111",
+              },
+            }
+        `);
+    });
+    test('simple value; without keyword', () => {
+        expect(referenceQuery(organizationParam, 'Organization/111', false)).toMatchInlineSnapshot(`
+            Object {
+              "multi_match": Object {
+                "fields": Array [
+                  "managingOrganization.reference",
                 ],
                 "lenient": true,
                 "query": "Organization/111",

--- a/src/QueryBuilder/typeQueries/referenceQuery.ts
+++ b/src/QueryBuilder/typeQueries/referenceQuery.ts
@@ -6,8 +6,10 @@
 import { CompiledSearchParam } from '../../FHIRSearchParametersRegistry';
 
 // eslint-disable-next-line import/prefer-default-export
-export function referenceQuery(compiled: CompiledSearchParam, value: string): any {
-    const fields = [`${compiled.path}.reference.keyword`];
+export function referenceQuery(compiled: CompiledSearchParam, value: string, useKeywordSubFields: boolean): any {
+    const keywordSuffix = useKeywordSubFields ? '.keyword' : '';
+
+    const fields = [`${compiled.path}.reference${keywordSuffix}`];
     return {
         multi_match: {
             fields,

--- a/src/QueryBuilder/typeQueries/tokenQuery.test.ts
+++ b/src/QueryBuilder/typeQueries/tokenQuery.test.ts
@@ -81,7 +81,7 @@ describe('parseTokenSearchParam', () => {
 
 describe('tokenQuery', () => {
     test('system|code', () => {
-        expect(tokenQuery(identifierParam, 'http://acme.org/patient|2345')).toMatchInlineSnapshot(`
+        expect(tokenQuery(identifierParam, 'http://acme.org/patient|2345', true)).toMatchInlineSnapshot(`
             Object {
               "bool": Object {
                 "must": Array [
@@ -113,7 +113,7 @@ describe('tokenQuery', () => {
         `);
     });
     test('system|', () => {
-        expect(tokenQuery(identifierParam, 'http://acme.org/patient')).toMatchInlineSnapshot(`
+        expect(tokenQuery(identifierParam, 'http://acme.org/patient', true)).toMatchInlineSnapshot(`
             Object {
               "multi_match": Object {
                 "fields": Array [
@@ -129,7 +129,7 @@ describe('tokenQuery', () => {
         `);
     });
     test('|code', () => {
-        expect(tokenQuery(identifierParam, '|2345')).toMatchInlineSnapshot(`
+        expect(tokenQuery(identifierParam, '|2345', true)).toMatchInlineSnapshot(`
             Object {
               "bool": Object {
                 "must": Array [
@@ -160,7 +160,7 @@ describe('tokenQuery', () => {
         `);
     });
     test('code', () => {
-        expect(tokenQuery(identifierParam, 'http://acme.org/patient|2345')).toMatchInlineSnapshot(`
+        expect(tokenQuery(identifierParam, 'http://acme.org/patient|2345', true)).toMatchInlineSnapshot(`
             Object {
               "bool": Object {
                 "must": Array [
@@ -180,6 +180,38 @@ describe('tokenQuery', () => {
                         "identifier.code.keyword",
                         "identifier.coding.code.keyword",
                         "identifier.value.keyword",
+                        "identifier",
+                      ],
+                      "lenient": true,
+                      "query": "2345",
+                    },
+                  },
+                ],
+              },
+            }
+        `);
+    });
+    test('code; without keyword', () => {
+        expect(tokenQuery(identifierParam, 'http://acme.org/patient|2345', false)).toMatchInlineSnapshot(`
+            Object {
+              "bool": Object {
+                "must": Array [
+                  Object {
+                    "multi_match": Object {
+                      "fields": Array [
+                        "identifier.system",
+                        "identifier.coding.system",
+                      ],
+                      "lenient": true,
+                      "query": "http://acme.org/patient",
+                    },
+                  },
+                  Object {
+                    "multi_match": Object {
+                      "fields": Array [
+                        "identifier.code",
+                        "identifier.coding.code",
+                        "identifier.value",
                         "identifier",
                       ],
                       "lenient": true,

--- a/src/QueryBuilder/typeQueries/tokenQuery.ts
+++ b/src/QueryBuilder/typeQueries/tokenQuery.ts
@@ -39,9 +39,10 @@ export const parseTokenSearchParam = (param: string): TokenSearchParameter => {
     return { system, code, explicitNoSystemProperty };
 };
 
-export function tokenQuery(compiled: CompiledSearchParam, value: string): any {
+export function tokenQuery(compiled: CompiledSearchParam, value: string, useKeywordSubFields: boolean): any {
     const { system, code, explicitNoSystemProperty } = parseTokenSearchParam(value);
     const queries = [];
+    const keywordSuffix = useKeywordSubFields ? '.keyword' : '';
 
     // Token search params are used for many different field types. Search is not aware of the types of the fields in FHIR resources.
     // The field type is specified in StructureDefinition, but not in SearchParameter.
@@ -50,8 +51,8 @@ export function tokenQuery(compiled: CompiledSearchParam, value: string): any {
     // See: https://www.hl7.org/fhir/search.html#token
     if (system !== undefined) {
         const fields = [
-            `${compiled.path}.system.keyword`, // Coding, Identifier
-            `${compiled.path}.coding.system.keyword`, // CodeableConcept
+            `${compiled.path}.system${keywordSuffix}`, // Coding, Identifier
+            `${compiled.path}.coding.system${keywordSuffix}`, // CodeableConcept
         ];
 
         queries.push({
@@ -65,9 +66,9 @@ export function tokenQuery(compiled: CompiledSearchParam, value: string): any {
 
     if (code !== undefined) {
         const fields = [
-            `${compiled.path}.code.keyword`, // Coding
-            `${compiled.path}.coding.code.keyword`, // CodeableConcept
-            `${compiled.path}.value.keyword`, // Identifier, ContactPoint
+            `${compiled.path}.code${keywordSuffix}`, // Coding
+            `${compiled.path}.coding.code${keywordSuffix}`, // CodeableConcept
+            `${compiled.path}.value${keywordSuffix}`, // Identifier, ContactPoint
             `${compiled.path}`, // code, boolean, uri, string
         ];
 

--- a/src/elasticSearchService.ts
+++ b/src/elasticSearchService.ts
@@ -49,6 +49,8 @@ export class ElasticSearchService implements Search {
 
     private readonly fhirSearchParametersRegistry: FHIRSearchParametersRegistry;
 
+    private readonly useKeywordSubFields: boolean;
+
     /**
      * @param searchFiltersForAllQueries - If you are storing both History and Search resources
      * in your elastic search you can filter out your History elements by supplying a list of SearchFilters
@@ -59,6 +61,7 @@ export class ElasticSearchService implements Search {
      * @param compiledImplementationGuides - The output of ImplementationGuides.compile.
      * This parameter enables support for search parameters defined in Implementation Guides.
      * @param esClient
+     * @param options.useKeywordSubFields - whether or not to append `.keyword` to fields in search queries. You should enable this if you do dynamic mapping
      */
     constructor(
         searchFiltersForAllQueries: SearchFilter[] = [],
@@ -68,12 +71,14 @@ export class ElasticSearchService implements Search {
         fhirVersion: FhirVersion = '4.0.1',
         compiledImplementationGuides?: any,
         esClient: Client = ElasticSearch,
+        { useKeywordSubFields = true }: { useKeywordSubFields?: boolean } = {},
     ) {
         this.searchFiltersForAllQueries = searchFiltersForAllQueries;
         this.cleanUpFunction = cleanUpFunction;
         this.fhirVersion = fhirVersion;
         this.fhirSearchParametersRegistry = new FHIRSearchParametersRegistry(fhirVersion, compiledImplementationGuides);
         this.esClient = esClient;
+        this.useKeywordSubFields = useKeywordSubFields;
     }
 
     async getCapabilities() {
@@ -108,7 +113,12 @@ export class ElasticSearchService implements Search {
                 ...this.searchFiltersForAllQueries,
                 ...(searchFilters ?? []),
             ]);
-            const query = buildQueryForAllSearchParameters(this.fhirSearchParametersRegistry, request, filter);
+            const query = buildQueryForAllSearchParameters(
+                this.fhirSearchParametersRegistry,
+                request,
+                this.useKeywordSubFields,
+                filter,
+            );
 
             const params: any = {
                 index: resourceType.toLowerCase(),
@@ -286,6 +296,7 @@ export class ElasticSearchService implements Search {
             searchEntries.map(x => x.resource),
             filter,
             this.fhirSearchParametersRegistry,
+            this.useKeywordSubFields,
             iterative,
         );
 

--- a/src/searchInclusions.ts
+++ b/src/searchInclusions.ts
@@ -195,7 +195,10 @@ export const buildRevIncludeQuery = (
     revIncludeSearchParameter: InclusionSearchParameter,
     references: string[],
     filterRulesForActiveResources: any[],
+    useKeywordSubFields: boolean,
 ) => {
+    const keywordSuffix = useKeywordSubFields ? '.keyword' : '';
+
     const { sourceResource, path } = revIncludeSearchParameter;
     return {
         index: sourceResource.toLowerCase(),
@@ -205,7 +208,7 @@ export const buildRevIncludeQuery = (
                     filter: [
                         {
                             terms: {
-                                [`${path}.reference.keyword`]: references,
+                                [`${path}.reference${keywordSuffix}`]: references,
                             },
                         },
                         ...filterRulesForActiveResources,
@@ -283,6 +286,7 @@ export const buildRevIncludeQueries = (
     resources: any[],
     filterRulesForActiveResources: any[],
     fhirSearchParametersRegistry: FHIRSearchParametersRegistry,
+    useKeywordSubFields: boolean,
     iterate?: true,
 ) => {
     const allRevincludeParameters = getInclusionParametersFromQueryParams('_revinclude', queryParams, iterate);
@@ -302,7 +306,7 @@ export const buildRevIncludeQueries = (
     const revincludeReferences = getRevincludeReferencesFromResources(revIncludeParameters, resources);
 
     const searchQueries = revincludeReferences.map(({ revinclude, references }) =>
-        buildRevIncludeQuery(revinclude, references, filterRulesForActiveResources),
+        buildRevIncludeQuery(revinclude, references, filterRulesForActiveResources, useKeywordSubFields),
     );
     return searchQueries;
 };


### PR DESCRIPTION
Description of changes:
- Adding new constructor parameter to pass-in if customer is using static mapping or not
  - if `true` .keyword will be added to the restricted search queries

NOTE this comes from and is the same PR as (#85)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.