### PR TITLE
Allow SearchParams with just an expression or just an xpath.

### DIFF
--- a/src/implementationGuides/__snapshots__/index.test.ts.snap
+++ b/src/implementationGuides/__snapshots__/index.test.ts.snap
@@ -168,6 +168,30 @@ Array [
 ]
 `;
 
+exports[`compile another where url value - MedicationKnowledge.extension.where(url='http://hl7.org/fhir/us/davinci-drug-formulary/StructureDefinition/usdf-PlanID-extension').value 1`] = `
+Array [
+  Object {
+    "base": "MedicationKnowledge",
+    "compiled": Array [
+      Object {
+        "condition": Array [
+          "extension.url",
+          "=",
+          "http://hl7.org/fhir/us/davinci-drug-formulary/StructureDefinition/usdf-PlanID-extension",
+        ],
+        "path": "extension.value",
+        "resourceType": "MedicationKnowledge",
+      },
+    ],
+    "description": "Accesses the DrugPlan ID of a FormularyDrug",
+    "name": "DrugPlan",
+    "target": undefined,
+    "type": "string",
+    "url": "http://hl7.org/fhir/us/davinci-drug-formulary/SearchParameter/DrugPlan",
+  },
+]
+`;
+
 exports[`compile as - (ConceptMap.source as uri) 1`] = `
 Array [
   Object {

--- a/src/implementationGuides/__snapshots__/index.test.ts.snap
+++ b/src/implementationGuides/__snapshots__/index.test.ts.snap
@@ -168,7 +168,28 @@ Array [
 ]
 `;
 
-exports[`compile another where url value - MedicationKnowledge.extension.where(url='http://hl7.org/fhir/us/davinci-drug-formulary/StructureDefinition/usdf-PlanID-extension').value 1`] = `
+exports[`compile as - (ConceptMap.source as uri) 1`] = `
+Array [
+  Object {
+    "base": "ConceptMap",
+    "compiled": Array [
+      Object {
+        "path": "sourceUri",
+        "resourceType": "ConceptMap",
+      },
+    ],
+    "description": "The source value set that contains the concepts that are being mapped",
+    "name": "source-uri",
+    "target": Array [
+      "ValueSet",
+    ],
+    "type": "reference",
+    "url": "http://hl7.org/fhir/SearchParameter/ConceptMap-source-uri",
+  },
+]
+`;
+
+exports[`compile expression only - MedicationKnowledge.extension.where(url='http://hl7.org/fhir/us/davinci-drug-formulary/StructureDefinition/usdf-PlanID-extension').value 1`] = `
 Array [
   Object {
     "base": "MedicationKnowledge",
@@ -188,27 +209,6 @@ Array [
     "target": undefined,
     "type": "string",
     "url": "http://hl7.org/fhir/us/davinci-drug-formulary/SearchParameter/DrugPlan",
-  },
-]
-`;
-
-exports[`compile as - (ConceptMap.source as uri) 1`] = `
-Array [
-  Object {
-    "base": "ConceptMap",
-    "compiled": Array [
-      Object {
-        "path": "sourceUri",
-        "resourceType": "ConceptMap",
-      },
-    ],
-    "description": "The source value set that contains the concepts that are being mapped",
-    "name": "source-uri",
-    "target": Array [
-      "ValueSet",
-    ],
-    "type": "reference",
-    "url": "http://hl7.org/fhir/SearchParameter/ConceptMap-source-uri",
   },
 ]
 `;

--- a/src/implementationGuides/index.test.ts
+++ b/src/implementationGuides/index.test.ts
@@ -144,6 +144,24 @@ describe('compile', () => {
         await expect(compiled).resolves.toMatchSnapshot();
     });
 
+    test(`another where url value - MedicationKnowledge.extension.where(url='http://hl7.org/fhir/us/davinci-drug-formulary/StructureDefinition/usdf-PlanID-extension').value`, async () => {
+        const compiled = compile([
+            {
+                resourceType: 'SearchParameter',
+                url: 'http://hl7.org/fhir/us/davinci-drug-formulary/SearchParameter/DrugPlan',
+                name: 'DrugPlan',
+                description: 'Accesses the DrugPlan ID of a FormularyDrug',
+                code: 'DrugPlan',
+                base: ['MedicationKnowledge'],
+                type: 'string',
+                expression:
+                    "MedicationKnowledge.extension.where(url='http://hl7.org/fhir/us/davinci-drug-formulary/StructureDefinition/usdf-PlanID-extension').value",
+                comparator: ['eq'],
+            },
+        ]);
+        await expect(compiled).resolves.toMatchSnapshot();
+    });
+
     test(`xpath explicitly expands choice of data types and fhirPath does not`, async () => {
         const compiled = compile([
             {

--- a/src/implementationGuides/index.test.ts
+++ b/src/implementationGuides/index.test.ts
@@ -144,7 +144,7 @@ describe('compile', () => {
         await expect(compiled).resolves.toMatchSnapshot();
     });
 
-    test(`another where url value - MedicationKnowledge.extension.where(url='http://hl7.org/fhir/us/davinci-drug-formulary/StructureDefinition/usdf-PlanID-extension').value`, async () => {
+    test(`expression only - MedicationKnowledge.extension.where(url='http://hl7.org/fhir/us/davinci-drug-formulary/StructureDefinition/usdf-PlanID-extension').value`, async () => {
         const compiled = compile([
             {
                 resourceType: 'SearchParameter',

--- a/src/implementationGuides/index.ts
+++ b/src/implementationGuides/index.ts
@@ -75,7 +75,7 @@ const isParamSupported = (searchParam: FhirSearchParam) => {
 
     if (!searchParam.expression && !searchParam.xpath) {
         logger.warn(
-            `search parameters without both a FHIRPath and an XPath expression are not supported. Skipping ${searchParam.url}`,
+            `search parameters without a FHIRPath or an XPath expression are not supported. Skipping ${searchParam.url}`,
         );
         return false;
     }


### PR DESCRIPTION
Description of changes:
We noticed that none of the 3 SearchParameters in http://hl7.org/fhir/us/davinci-drug-formulary/artifacts.html#2 are being compiled because they only use `expression` and are lacking an `xpath`. It seems having an `xpath` isn't really necessary since the compiler merges the results of the two expression parsers. 
So if only either `expression` or `xpath` are present we can just parse one expression and use its result. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.