### PR TITLE
fix: handle _include refs in paths with arrays

### DIFF
--- a/src/__snapshots__/elasticSearchService.test.ts.snap
+++ b/src/__snapshots__/elasticSearchService.test.ts.snap
@@ -342,6 +342,68 @@ Array [
 ]
 `;
 
+exports[`typeSearch _include search param with array fields: msearch queries 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Array [
+        Object {
+          "index": "location-alias",
+        },
+        Object {
+          "query": Object {
+            "bool": Object {
+              "filter": Array [
+                Object {
+                  "terms": Object {
+                    "id": Array [
+                      "location-id-111",
+                      "location-id-222",
+                    ],
+                  },
+                },
+                Object {
+                  "match": Object {
+                    "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+  ],
+]
+`;
+
+exports[`typeSearch _include search param with array fields: search queries 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [],
+          },
+        },
+      },
+      "from": 0,
+      "index": "encounter-alias",
+      "size": 20,
+      "track_total_hits": true,
+    },
+  ],
+]
+`;
+
 exports[`typeSearch _include wildcard include with restrictive allowed resource types: msearch queries 1`] = `Array []`;
 
 exports[`typeSearch _include wildcard include with restrictive allowed resource types: search queries 1`] = `

--- a/src/elasticSearchService.test.ts
+++ b/src/elasticSearchService.test.ts
@@ -390,6 +390,52 @@ describe('typeSearch', () => {
         },
     };
 
+    const fakeEncounterSearchResult = {
+        body: {
+            took: 5,
+            timed_out: false,
+            _shards: {
+                total: 5,
+                successful: 5,
+                skipped: 0,
+                failed: 0,
+            },
+            hits: {
+                total: {
+                    value: 1,
+                    relation: 'eq',
+                },
+                max_score: 1.0,
+                hits: [
+                    {
+                        _index: 'encounter',
+                        _type: '_doc',
+                        _id: 'encounter-id-111_1',
+                        _score: 1.0,
+                        _source: {
+                            vid: '1',
+                            location: [
+                                {
+                                    location: {
+                                        reference: 'Location/location-id-111',
+                                    },
+                                },
+                                {
+                                    location: {
+                                        reference: 'Location/location-id-222',
+                                    },
+                                },
+                            ],
+                            documentStatus: 'AVAILABLE',
+                            id: 'encounter-id-111',
+                            resourceType: 'Encounter',
+                        },
+                    },
+                ],
+            },
+        },
+    };
+
     const emptyMsearchResult = {
         body: {
             responses: [],
@@ -429,6 +475,22 @@ describe('typeSearch', () => {
                 baseUrl: 'https://base-url.com',
                 queryParams: { _include: '*' },
                 allowedResourceTypes: ['MedicationRequest'],
+            });
+
+            expect((ElasticSearch.search as jest.Mock).mock.calls).toMatchSnapshot('search queries');
+            expect((ElasticSearch.msearch as jest.Mock).mock.calls).toMatchSnapshot('msearch queries');
+        });
+
+        test('search param with array fields', async () => {
+            (ElasticSearch.search as jest.Mock).mockResolvedValue(fakeEncounterSearchResult);
+            (ElasticSearch.msearch as jest.Mock).mockResolvedValue(emptyMsearchResult);
+
+            const es = new ElasticSearchService(FILTER_RULES_FOR_ACTIVE_RESOURCES);
+            await es.typeSearch({
+                resourceType: 'Encounter',
+                baseUrl: 'https://base-url.com',
+                queryParams: { _include: 'Encounter:location' },
+                allowedResourceTypes: ['Encounter', 'Location'],
             });
 
             expect((ElasticSearch.search as jest.Mock).mock.calls).toMatchSnapshot('search queries');

--- a/src/getAllValuesForFHIRPath.test.ts
+++ b/src/getAllValuesForFHIRPath.test.ts
@@ -1,0 +1,50 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { getAllValuesForFHIRPath } from './getAllValuesForFHIRPath';
+
+describe('getAllValuesForFHIRPath', () => {
+    test('simple path', () => {
+        const values = getAllValuesForFHIRPath({ a: { b: { c: 1 } } }, 'a.b.c');
+        expect(values).toMatchInlineSnapshot(`
+            Array [
+              1,
+            ]
+        `);
+    });
+
+    test('intermediate array', () => {
+        const values = getAllValuesForFHIRPath({ a: [{ b: { c: 1 } }, { b: { c: 2 } }] }, 'a.b.c');
+        expect(values).toMatchInlineSnapshot(`
+            Array [
+              1,
+              2,
+            ]
+        `);
+    });
+
+    test('all arrays', () => {
+        const values = getAllValuesForFHIRPath({ a: [{ b: { c: [1, 2] } }, { b: { c: [3, 4] } }] }, 'a.b.c');
+        expect(values).toMatchInlineSnapshot(`
+            Array [
+              1,
+              2,
+              3,
+              4,
+            ]
+        `);
+    });
+
+    test('non-existent path', () => {
+        const values = getAllValuesForFHIRPath({ a: { b: { c: 1 } } }, 'some.path.x');
+        expect(values).toMatchInlineSnapshot(`Array []`);
+    });
+
+    test('empty resource', () => {
+        const values = getAllValuesForFHIRPath({}, 'a.b.c');
+        expect(values).toMatchInlineSnapshot(`Array []`);
+    });
+});

--- a/src/getAllValuesForFHIRPath.ts
+++ b/src/getAllValuesForFHIRPath.ts
@@ -1,0 +1,36 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+// eslint-disable-next-line import/prefer-default-export
+import { isPresent } from './tsUtils';
+
+/**
+ * Gets all values in the given FHIRPath. This function properly handles intermediate array fields.
+ *
+ * FHIRPath can be misleading since it does not explicitly states the cardinality of fields.
+ * e.g. for "Encounter.location.location", "Encounter.location" is an array, so you would access the 1st value as "Encounter.location[0].location"
+ *
+ * Note: This function can be further optimized by knowing beforehand which fields are arrays. That info can be derived from the FHIR StructureDefinitions
+ *
+ * @param resource - FHIR resource
+ * @param path - path to look for
+ *
+ * @return array of all values located in the given path.
+ */
+// eslint-disable-next-line import/prefer-default-export
+export const getAllValuesForFHIRPath = (resource: any, path: string): any[] => {
+    const pathParts = path.split('.');
+
+    let values: any[] = [resource];
+    let pathTraversed = '';
+
+    pathParts.forEach(pathPart => {
+        pathTraversed = pathTraversed === '' ? pathPart : `${pathTraversed}.${pathPart}`;
+        values = values.flatMap(value => value[pathPart]).filter(isPresent);
+    });
+
+    return values;
+};

--- a/src/searchInclusions.test.ts
+++ b/src/searchInclusions.test.ts
@@ -261,6 +261,47 @@ describe('getIncludeReferencesFromResources', () => {
         expect(refs).toEqual(expected);
     });
 
+    test('path with intermediate arrays', () => {
+        const includeSearchParams: InclusionSearchParameter[] = [
+            {
+                isWildcard: false,
+                type: '_include',
+                searchParameter: 'someField',
+                path: 'someField.multiple.single',
+                sourceResource: 'Patient',
+                targetResourceType: '',
+            },
+        ];
+
+        const resources: any[] = [
+            {
+                resourceType: 'Patient',
+                someField: {
+                    multiple: [
+                        {
+                            single: {
+                                reference: 'Practitioner/111',
+                            },
+                        },
+                        {
+                            single: {
+                                reference: 'Organization/222',
+                            },
+                        },
+                    ],
+                },
+            },
+        ];
+
+        const refs = getIncludeReferencesFromResources(includeSearchParams, resources);
+
+        const expected = [
+            { resourceType: 'Practitioner', id: '111' },
+            { resourceType: 'Organization', id: '222' },
+        ];
+        expect(refs).toEqual(expected);
+    });
+
     test('searchParameter with dot', () => {
         const includeSearchParams: InclusionSearchParameter[] = [
             {

--- a/src/searchInclusions.ts
+++ b/src/searchInclusions.ts
@@ -7,7 +7,6 @@ import { groupBy, mapValues, uniq, get, uniqBy } from 'lodash';
 import { isPresent } from './tsUtils';
 import { FHIRSearchParametersRegistry } from './FHIRSearchParametersRegistry';
 import getComponentLogger from './loggerBuilder';
-import { Query } from './elasticSearchService';
 import { getAllValuesForFHIRPath } from './getAllValuesForFHIRPath';
 
 const logger = getComponentLogger();

--- a/src/searchInclusions.ts
+++ b/src/searchInclusions.ts
@@ -7,6 +7,8 @@ import { groupBy, mapValues, uniq, get, uniqBy } from 'lodash';
 import { isPresent } from './tsUtils';
 import { FHIRSearchParametersRegistry } from './FHIRSearchParametersRegistry';
 import getComponentLogger from './loggerBuilder';
+import { Query } from './elasticSearchService';
+import { getAllValuesForFHIRPath } from './getAllValuesForFHIRPath';
 
 const logger = getComponentLogger();
 
@@ -132,7 +134,7 @@ export const getIncludeReferencesFromResources = (
     const references = includes.flatMap(include => {
         return resources
             .filter(resource => resource.resourceType === include.sourceResource)
-            .map(resource => get(resource, `${include.path}`) as any)
+            .flatMap(resource => getAllValuesForFHIRPath(resource, `${include.path}`))
             .flatMap(valueAtPath => {
                 if (Array.isArray(valueAtPath)) {
                     return valueAtPath.map(v => get(v, 'reference'));


### PR DESCRIPTION
Fix: https://github.com/awslabs/fhir-works-on-aws-search-es/issues/94

Our `_include` code was not handling the case where paths to references had intermediate array fields. This fixes it.

e.g. The search param `location` for `Encounter` has the FHIRPath expression `Encounter.location.location`, but `Encounter.location` is an array. Attempting to get the value at `Encounter.location.location` resulted in undefined due to the intermediate array and the referenced resources were not included.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.