### PR TITLE
fix: remove duplicate Resource search params

### DIFF
--- a/src/FHIRSearchParametersRegistry/index.test.ts
+++ b/src/FHIRSearchParametersRegistry/index.test.ts
@@ -123,6 +123,65 @@ describe('FHIRSearchParametersRegistry', () => {
                   "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-given",
                 }
             `);
+
+            expect(fhirSearchParametersRegistry.getCapabilities().Patient.searchParam.filter(s => s.name === 'given'))
+                .toMatchInlineSnapshot(`
+                Array [
+                  Object {
+                    "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-given",
+                    "documentation": "a long us core description",
+                    "name": "given",
+                    "type": "string",
+                  },
+                ]
+            `);
+        });
+
+        test('IGs search params for Resource should overwrite base FHIR search params', () => {
+            const IGCompiledSearchParams = [
+                {
+                    name: '_id',
+                    url: 'http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-id',
+                    type: 'token',
+                    description: 'a long us core description',
+                    base: 'Patient',
+                    compiled: [
+                        {
+                            resourceType: 'Patient',
+                            path: 'id',
+                        },
+                    ],
+                },
+            ];
+
+            const fhirSearchParametersRegistry = new FHIRSearchParametersRegistry('4.0.1', IGCompiledSearchParams);
+            expect(fhirSearchParametersRegistry.getSearchParameter('Patient', '_id')).toMatchInlineSnapshot(`
+                Object {
+                  "base": "Patient",
+                  "compiled": Array [
+                    Object {
+                      "path": "id",
+                      "resourceType": "Patient",
+                    },
+                  ],
+                  "description": "a long us core description",
+                  "name": "_id",
+                  "type": "token",
+                  "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-id",
+                }
+            `);
+
+            expect(fhirSearchParametersRegistry.getCapabilities().Patient.searchParam.filter(s => s.name === '_id'))
+                .toMatchInlineSnapshot(`
+                Array [
+                  Object {
+                    "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-id",
+                    "documentation": "a long us core description",
+                    "name": "_id",
+                    "type": "token",
+                  },
+                ]
+            `);
         });
     });
 });

--- a/src/FHIRSearchParametersRegistry/index.ts
+++ b/src/FHIRSearchParametersRegistry/index.ts
@@ -148,6 +148,8 @@ export class FHIRSearchParametersRegistry {
 
         const resourceSearchParams = Object.values(this.typeNameMap.Resource).map(toCapabilityStatement);
 
+        // For each resource type, add all search params that have "Resource" as base, except when there is already
+        // a more specific search parameter with the same name.
         Object.entries(this.capabilityStatement).forEach(([resourceType, searchCapabilities]) => {
             searchCapabilities.searchParam.push(
                 ...resourceSearchParams.filter(

--- a/src/FHIRSearchParametersRegistry/index.ts
+++ b/src/FHIRSearchParametersRegistry/index.ts
@@ -148,8 +148,12 @@ export class FHIRSearchParametersRegistry {
 
         const resourceSearchParams = Object.values(this.typeNameMap.Resource).map(toCapabilityStatement);
 
-        Object.values(this.capabilityStatement).forEach(searchCapabilities => {
-            searchCapabilities.searchParam.push(...resourceSearchParams);
+        Object.entries(this.capabilityStatement).forEach(([resourceType, searchCapabilities]) => {
+            searchCapabilities.searchParam.push(
+                ...resourceSearchParams.filter(
+                    resourceSearchParam => !this.typeNameMap?.[resourceType]?.[resourceSearchParam.name],
+                ),
+            );
         });
     }
 


### PR DESCRIPTION
Fixes part of https://github.com/awslabs/fhir-works-on-aws-routing/issues/106

The capability statement validation was failing with errors like:
`ERROR: Search parameter names must be unique in the context of a resource. [searchParam.select(name).isDistinct()]`

Search params for `Resource` are applied to all resources (e.g. the `_id` param). The bug was that this params were added without checking if there was already a more specific param with the same name for a specific resource type(e.g. US Core defines a more specific `_id` for `Encounter`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.