### PR TITLE
feat: allow id only reference searches when valid

### DIFF
--- a/src/QueryBuilder/index.ts
+++ b/src/QueryBuilder/index.ts
@@ -39,7 +39,13 @@ function typeQueryWithConditions(
             typeQuery = quantityQuery(compiledSearchParam, searchValue, useKeywordSubFields);
             break;
         case 'reference':
-            typeQuery = referenceQuery(compiledSearchParam, searchValue, useKeywordSubFields);
+            typeQuery = referenceQuery(
+                compiledSearchParam,
+                searchValue,
+                useKeywordSubFields,
+                searchParam.name,
+                searchParam.target,
+            );
             break;
         case 'uri':
             typeQuery = uriQuery(compiledSearchParam, searchValue, useKeywordSubFields);

--- a/src/QueryBuilder/typeQueries/referenceQuery.test.ts
+++ b/src/QueryBuilder/typeQueries/referenceQuery.test.ts
@@ -14,12 +14,10 @@ describe('referenceQuery', () => {
     test('simple value; with keyword', () => {
         expect(referenceQuery(organizationParam, 'Organization/111', true, 'organization', [])).toMatchInlineSnapshot(`
             Object {
-              "multi_match": Object {
-                "fields": Array [
-                  "managingOrganization.reference.keyword",
+              "terms": Object {
+                "managingOrganization.reference.keyword": Array [
+                  "Organization/111",
                 ],
-                "lenient": true,
-                "query": "Organization/111",
               },
             }
         `);
@@ -28,34 +26,38 @@ describe('referenceQuery', () => {
         expect(referenceQuery(organizationParam, 'http://fhir.com/baseR4/Organization/111', false, 'organization'))
             .toMatchInlineSnapshot(`
             Object {
-              "multi_match": Object {
-                "fields": Array [
-                  "managingOrganization.reference",
+              "terms": Object {
+                "managingOrganization.reference": Array [
+                  "http://fhir.com/baseR4/Organization/111",
                 ],
-                "lenient": true,
-                "query": "http://fhir.com/baseR4/Organization/111",
               },
             }
         `);
     });
     test('just id search, one type found', () => {
-        expect(referenceQuery(organizationParam, 'organizationId', false, 'organization', ['Organization']))
+        expect(referenceQuery(organizationParam, 'organizationId', true, 'organization', ['Organization']))
             .toMatchInlineSnapshot(`
             Object {
-              "multi_match": Object {
-                "fields": Array [
-                  "managingOrganization.reference",
+              "terms": Object {
+                "managingOrganization.reference.keyword": Array [
+                  "Organization/organizationId",
                 ],
-                "lenient": true,
-                "query": "Organization/organizationId",
               },
             }
         `);
     });
     test('just id search, many types found', () => {
-        expect(() =>
-            referenceQuery(organizationParam, 'organizationId', false, 'organization', ['Organization', 'Group']),
-        ).toThrow(InvalidSearchParameterError);
+        expect(referenceQuery(organizationParam, 'organizationId', true, 'organization', ['Organization', 'Group']))
+            .toMatchInlineSnapshot(`
+            Object {
+              "terms": Object {
+                "managingOrganization.reference.keyword": Array [
+                  "Organization/organizationId",
+                  "Group/organizationId",
+                ],
+              },
+            }
+    `);
     });
     test('just id search, no types found', () => {
         expect(() => referenceQuery(organizationParam, 'organizationId', false, 'organization')).toThrow(

--- a/src/QueryBuilder/typeQueries/referenceQuery.test.ts
+++ b/src/QueryBuilder/typeQueries/referenceQuery.test.ts
@@ -3,6 +3,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
+import { InvalidSearchParameterError } from 'fhir-works-on-aws-interface';
 import { referenceQuery } from './referenceQuery';
 import { FHIRSearchParametersRegistry } from '../../FHIRSearchParametersRegistry';
 
@@ -11,7 +12,7 @@ const organizationParam = fhirSearchParametersRegistry.getSearchParameter('Patie
 
 describe('referenceQuery', () => {
     test('simple value; with keyword', () => {
-        expect(referenceQuery(organizationParam, 'Organization/111', true)).toMatchInlineSnapshot(`
+        expect(referenceQuery(organizationParam, 'Organization/111', true, 'organization', [])).toMatchInlineSnapshot(`
             Object {
               "multi_match": Object {
                 "fields": Array [
@@ -24,16 +25,41 @@ describe('referenceQuery', () => {
         `);
     });
     test('simple value; without keyword', () => {
-        expect(referenceQuery(organizationParam, 'Organization/111', false)).toMatchInlineSnapshot(`
+        expect(referenceQuery(organizationParam, 'http://fhir.com/baseR4/Organization/111', false, 'organization'))
+            .toMatchInlineSnapshot(`
             Object {
               "multi_match": Object {
                 "fields": Array [
                   "managingOrganization.reference",
                 ],
                 "lenient": true,
-                "query": "Organization/111",
+                "query": "http://fhir.com/baseR4/Organization/111",
               },
             }
         `);
+    });
+    test('just id search, one type found', () => {
+        expect(referenceQuery(organizationParam, 'orgnaizationId', false, 'organization', ['Organization']))
+            .toMatchInlineSnapshot(`
+            Object {
+              "multi_match": Object {
+                "fields": Array [
+                  "managingOrganization.reference",
+                ],
+                "lenient": true,
+                "query": "Organization/orgnaizationId",
+              },
+            }
+        `);
+    });
+    test('just id search, many types found', () => {
+        expect(() =>
+            referenceQuery(organizationParam, 'orgnaizationId', false, 'organization', ['Organization', 'Group']),
+        ).toThrow(InvalidSearchParameterError);
+    });
+    test('just id search, no types found', () => {
+        expect(() => referenceQuery(organizationParam, 'orgnaizationId', false, 'organization')).toThrow(
+            InvalidSearchParameterError,
+        );
     });
 });

--- a/src/QueryBuilder/typeQueries/referenceQuery.test.ts
+++ b/src/QueryBuilder/typeQueries/referenceQuery.test.ts
@@ -39,7 +39,7 @@ describe('referenceQuery', () => {
         `);
     });
     test('just id search, one type found', () => {
-        expect(referenceQuery(organizationParam, 'orgnaizationId', false, 'organization', ['Organization']))
+        expect(referenceQuery(organizationParam, 'organizationId', false, 'organization', ['Organization']))
             .toMatchInlineSnapshot(`
             Object {
               "multi_match": Object {
@@ -47,18 +47,18 @@ describe('referenceQuery', () => {
                   "managingOrganization.reference",
                 ],
                 "lenient": true,
-                "query": "Organization/orgnaizationId",
+                "query": "Organization/organizationId",
               },
             }
         `);
     });
     test('just id search, many types found', () => {
         expect(() =>
-            referenceQuery(organizationParam, 'orgnaizationId', false, 'organization', ['Organization', 'Group']),
+            referenceQuery(organizationParam, 'organizationId', false, 'organization', ['Organization', 'Group']),
         ).toThrow(InvalidSearchParameterError);
     });
     test('just id search, no types found', () => {
-        expect(() => referenceQuery(organizationParam, 'orgnaizationId', false, 'organization')).toThrow(
+        expect(() => referenceQuery(organizationParam, 'organizationId', false, 'organization')).toThrow(
             InvalidSearchParameterError,
         );
     });

--- a/src/QueryBuilder/typeQueries/referenceQuery.test.ts
+++ b/src/QueryBuilder/typeQueries/referenceQuery.test.ts
@@ -23,11 +23,22 @@ describe('referenceQuery', () => {
         `);
     });
     test('simple value; without keyword', () => {
-        expect(referenceQuery(organizationParam, 'http://fhir.com/baseR4/Organization/111', false, 'organization'))
-            .toMatchInlineSnapshot(`
+        expect(referenceQuery(organizationParam, 'Organization/111', false, 'organization')).toMatchInlineSnapshot(`
             Object {
               "terms": Object {
                 "managingOrganization.reference": Array [
+                  "Organization/111",
+                ],
+              },
+            }
+        `);
+    });
+    test('reference search with full URL', () => {
+        expect(referenceQuery(organizationParam, 'http://fhir.com/baseR4/Organization/111', true, 'organization'))
+            .toMatchInlineSnapshot(`
+            Object {
+              "terms": Object {
+                "managingOrganization.reference.keyword": Array [
                   "http://fhir.com/baseR4/Organization/111",
                 ],
               },

--- a/src/QueryBuilder/typeQueries/referenceQuery.ts
+++ b/src/QueryBuilder/typeQueries/referenceQuery.ts
@@ -3,17 +3,39 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
+import { InvalidSearchParameterError } from 'fhir-works-on-aws-interface';
 import { CompiledSearchParam } from '../../FHIRSearchParametersRegistry';
 
+const idOnlyRegExp = /^[A-Za-z0-9\-.]{1,64}$/;
+
 // eslint-disable-next-line import/prefer-default-export
-export function referenceQuery(compiled: CompiledSearchParam, value: string, useKeywordSubFields: boolean): any {
+export function referenceQuery(
+    compiled: CompiledSearchParam,
+    value: string,
+    useKeywordSubFields: boolean,
+    searchParamName: string,
+    target: string[] = [],
+): any {
     const keywordSuffix = useKeywordSubFields ? '.keyword' : '';
 
     const fields = [`${compiled.path}.reference${keywordSuffix}`];
+    let reference = value;
+    // http://hl7.org/fhir/R4/search.html#reference
+    // to cover the use-case of someone searching as just an 'id' and this reference just has 1 target i.e. Observation.patient = 123
+    if (value.match(idOnlyRegExp)) {
+        if (target.length === 1) {
+            reference = `${target[0]}/${value}`;
+        } else {
+            throw new InvalidSearchParameterError(
+                `'${searchParamName}' is invalid please specify the resource type with the id`,
+            );
+        }
+    }
+
     return {
         multi_match: {
             fields,
-            query: value,
+            query: reference,
             lenient: true,
         },
     };

--- a/src/QueryBuilder/typeQueries/referenceQuery.ts
+++ b/src/QueryBuilder/typeQueries/referenceQuery.ts
@@ -5,6 +5,9 @@
 
 import { InvalidSearchParameterError } from 'fhir-works-on-aws-interface';
 import { CompiledSearchParam } from '../../FHIRSearchParametersRegistry';
+import getComponentLogger from '../../loggerBuilder';
+
+const logger = getComponentLogger();
 
 const idOnlyRegExp = /^[A-Za-z0-9\-.]{1,64}$/;
 
@@ -23,8 +26,11 @@ export function referenceQuery(
     let references: string[] = [value];
     if (value.match(idOnlyRegExp)) {
         if (target.length === 0) {
+            logger.error(
+                `ID only reference search failed. The requested search parameter: '${searchParamName}',  does not have any targets. Please ensure the compiled IG is valid`,
+            );
             throw new InvalidSearchParameterError(
-                `'${searchParamName}' is invalid please specify the reference value with the format [resourcetType]/[id] or as an absolute URL`,
+                `ID only search for '${searchParamName}' parameter is not supported, please specify the value with the format [resourcetType]/[id] or as an absolute URL`,
             );
         }
 

--- a/src/QueryBuilder/typeQueries/referenceQuery.ts
+++ b/src/QueryBuilder/typeQueries/referenceQuery.ts
@@ -27,7 +27,7 @@ export function referenceQuery(
             reference = `${target[0]}/${value}`;
         } else {
             throw new InvalidSearchParameterError(
-                `'${searchParamName}' is invalid please specify the resource type with the id`,
+                `'${searchParamName}' is invalid please specify the reference value with the format [resourcetType]/[id] or as an absolute URL`,
             );
         }
     }

--- a/src/__snapshots__/elasticSearchService.test.ts.snap
+++ b/src/__snapshots__/elasticSearchService.test.ts.snap
@@ -2586,7 +2586,7 @@ Array [
 ]
 `;
 
-exports[`typeSearch search parameters with complex expressions queryParams={"depends-on":"something"} 1`] = `
+exports[`typeSearch search parameters with complex expressions queryParams={"depends-on":"Patient/something"} 1`] = `
 Array [
   Array [
     Object {
@@ -2610,7 +2610,7 @@ Array [
                           "relatedArtifact.resource.reference.keyword",
                         ],
                         "lenient": true,
-                        "query": "something",
+                        "query": "Patient/something",
                       },
                     },
                     Object {

--- a/src/__snapshots__/elasticSearchService.test.ts.snap
+++ b/src/__snapshots__/elasticSearchService.test.ts.snap
@@ -2445,6 +2445,43 @@ Array [
 ]
 `;
 
+exports[`typeSearch query snapshots for simple queryParams; with ACTIVE filter queryParams={"general-practitioner":"1234"} 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [
+              Object {
+                "terms": Object {
+                  "generalPractitioner.reference.keyword": Array [
+                    "Practitioner/1234",
+                    "Organization/1234",
+                    "PractitionerRole/1234",
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient-alias",
+      "size": 20,
+      "track_total_hits": true,
+    },
+  ],
+]
+`;
+
 exports[`typeSearch query snapshots for simple queryParams; with ACTIVE filter queryParams={"general-practitioner":"Practitioner/1234"} 1`] = `
 Array [
   Array [
@@ -2461,12 +2498,45 @@ Array [
             ],
             "must": Array [
               Object {
-                "multi_match": Object {
-                  "fields": Array [
-                    "generalPractitioner.reference.keyword",
+                "terms": Object {
+                  "generalPractitioner.reference.keyword": Array [
+                    "Practitioner/1234",
                   ],
-                  "lenient": true,
-                  "query": "Practitioner/1234",
+                },
+              },
+            ],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient-alias",
+      "size": 20,
+      "track_total_hits": true,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch query snapshots for simple queryParams; with ACTIVE filter queryParams={"organization":"1234"} 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [
+              Object {
+                "terms": Object {
+                  "managingOrganization.reference.keyword": Array [
+                    "Organization/1234",
+                  ],
                 },
               },
             ],
@@ -2605,12 +2675,10 @@ Array [
                 "bool": Object {
                   "must": Array [
                     Object {
-                      "multi_match": Object {
-                        "fields": Array [
-                          "relatedArtifact.resource.reference.keyword",
+                      "terms": Object {
+                        "relatedArtifact.resource.reference.keyword": Array [
+                          "Patient/something",
                         ],
-                        "lenient": true,
-                        "query": "Patient/something",
                       },
                     },
                     Object {
@@ -2714,12 +2782,10 @@ Array [
                 "bool": Object {
                   "must": Array [
                     Object {
-                      "multi_match": Object {
-                        "fields": Array [
-                          "link.target.reference.keyword",
+                      "terms": Object {
+                        "link.target.reference.keyword": Array [
+                          "RelatedPerson/111",
                         ],
-                        "lenient": true,
-                        "query": "RelatedPerson/111",
                       },
                     },
                     Object {

--- a/src/elasticSearchService.test.ts
+++ b/src/elasticSearchService.test.ts
@@ -52,6 +52,8 @@ describe('typeSearch', () => {
             [{ _format: 'json' }],
             [{ _profile: 'http://hl7.org/fhir/us/carin-bb/StructureDefinition/C4BB-ExplanationOfBenefit-Pharmacy' }],
             [{ 'general-practitioner': 'Practitioner/1234' }],
+            [{ 'general-practitioner': '1234' }],
+            [{ organization: '1234' }],
             [
                 {
                     _count: '10',
@@ -277,18 +279,6 @@ describe('typeSearch', () => {
                 resourceType: 'Patient',
                 baseUrl: 'https://base-url.com',
                 queryParams: { someFieldThatDoesNotExist: 'someValue' },
-                allowedResourceTypes: ALLOWED_RESOURCE_TYPES,
-            }),
-        ).rejects.toThrowError(InvalidSearchParameterError);
-    });
-
-    test('Invalid Parameter; reference search with an id', () => {
-        const es = new ElasticSearchService(FILTER_RULES_FOR_ACTIVE_RESOURCES);
-        expect(
-            es.typeSearch({
-                resourceType: 'Patient',
-                baseUrl: 'https://base-url.com',
-                queryParams: { generalPractitioner: 'idWithoutType' },
                 allowedResourceTypes: ALLOWED_RESOURCE_TYPES,
             }),
         ).rejects.toThrowError(InvalidSearchParameterError);

--- a/src/elasticSearchService.test.ts
+++ b/src/elasticSearchService.test.ts
@@ -230,7 +230,7 @@ describe('typeSearch', () => {
         each([
             [{ phone: '1234567' }, 'Patient'],
             [{ 'value-string': 'some value' }, 'Observation'],
-            [{ 'depends-on': 'something' }, 'Library'],
+            [{ 'depends-on': 'Patient/something' }, 'Library'],
             [{ relatedperson: 'RelatedPerson/111' }, 'Person'],
         ]).test('queryParams=%j', async (queryParams: any, resourceType: string) => {
             const fakeSearchResult = {
@@ -277,6 +277,18 @@ describe('typeSearch', () => {
                 resourceType: 'Patient',
                 baseUrl: 'https://base-url.com',
                 queryParams: { someFieldThatDoesNotExist: 'someValue' },
+                allowedResourceTypes: ALLOWED_RESOURCE_TYPES,
+            }),
+        ).rejects.toThrowError(InvalidSearchParameterError);
+    });
+
+    test('Invalid Parameter; reference search with an id', () => {
+        const es = new ElasticSearchService(FILTER_RULES_FOR_ACTIVE_RESOURCES);
+        expect(
+            es.typeSearch({
+                resourceType: 'Patient',
+                baseUrl: 'https://base-url.com',
+                queryParams: { generalPractitioner: 'idWithoutType' },
                 allowedResourceTypes: ALLOWED_RESOURCE_TYPES,
             }),
         ).rejects.toThrowError(InvalidSearchParameterError);


### PR DESCRIPTION
Issue #, if available: #106

FHIR spec:
> Some references may point to more than one type of resource; e.g. subject: Reference(Patient|Group|Device|..). In these cases, multiple resources may have the same logical identifier. Servers SHOULD reject a search where the logical id refers to more than one matching resource across different types. In order to allow the client to perform a search in these situations the type is specified explicitly

http://hl7.org/fhir/R4/search.html#reference

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.