### PR TITLE
fix: fix _id searches

### DIFF
--- a/src/QueryBuilder/typeQueries/tokenQuery.ts
+++ b/src/QueryBuilder/typeQueries/tokenQuery.ts
@@ -14,7 +14,7 @@ interface TokenSearchParameter {
 
 const SUPPORTED_MODIFIERS: string[] = [];
 
-// Fields that do not have `.keyword` suffix; currently it is just `id`. This is only important if `useKeywordSubFields` is true
+// Fields that do not have `.keyword` suffix. This is only important if `useKeywordSubFields` is true
 const FIELDS_WITHOUT_KEYWORD = ['id'];
 
 // eslint-disable-next-line import/prefer-default-export

--- a/src/QueryBuilder/typeQueries/tokenQuery.ts
+++ b/src/QueryBuilder/typeQueries/tokenQuery.ts
@@ -14,6 +14,9 @@ interface TokenSearchParameter {
 
 const SUPPORTED_MODIFIERS: string[] = [];
 
+// Fields that do not have `.keyword` suffix; currently it is just `id`. This is only important if `useKeywordSubFields` is true
+const FIELDS_WITHOUT_KEYWORD = ['id'];
+
 // eslint-disable-next-line import/prefer-default-export
 export const parseTokenSearchParam = (param: string): TokenSearchParameter => {
     if (param === '|') {
@@ -52,7 +55,7 @@ export function tokenQuery(
     }
     const { system, code, explicitNoSystemProperty } = parseTokenSearchParam(value);
     const queries = [];
-    const keywordSuffix = useKeywordSubFields ? '.keyword' : '';
+    const keywordSuffix = useKeywordSubFields && !FIELDS_WITHOUT_KEYWORD.includes(compiled.path) ? '.keyword' : '';
 
     // Token search params are used for many different field types. Search is not aware of the types of the fields in FHIR resources.
     // The field type is specified in StructureDefinition, but not in SearchParameter.

--- a/src/__snapshots__/elasticSearchService.test.ts.snap
+++ b/src/__snapshots__/elasticSearchService.test.ts.snap
@@ -1594,10 +1594,10 @@ Array [
               Object {
                 "multi_match": Object {
                   "fields": Array [
-                    "id.code.keyword",
-                    "id.coding.code.keyword",
-                    "id.value.keyword",
-                    "id.keyword",
+                    "id.code",
+                    "id.coding.code",
+                    "id.value",
+                    "id",
                   ],
                   "lenient": true,
                   "query": "11111111-1111-1111-1111-111111111111",
@@ -1818,10 +1818,10 @@ Array [
               Object {
                 "multi_match": Object {
                   "fields": Array [
-                    "id.code.keyword",
-                    "id.coding.code.keyword",
-                    "id.value.keyword",
-                    "id.keyword",
+                    "id.code",
+                    "id.coding.code",
+                    "id.value",
+                    "id",
                   ],
                   "lenient": true,
                   "query": "11111111-1111-1111-1111-111111111111",
@@ -1948,10 +1948,10 @@ Array [
               Object {
                 "multi_match": Object {
                   "fields": Array [
-                    "id.code.keyword",
-                    "id.coding.code.keyword",
-                    "id.value.keyword",
-                    "id.keyword",
+                    "id.code",
+                    "id.coding.code",
+                    "id.value",
+                    "id",
                   ],
                   "lenient": true,
                   "query": "11111111-1111-1111-1111-111111111111",
@@ -2596,10 +2596,10 @@ Array [
               Object {
                 "multi_match": Object {
                   "fields": Array [
-                    "id.code.keyword",
-                    "id.coding.code.keyword",
-                    "id.value.keyword",
-                    "id.keyword",
+                    "id.code",
+                    "id.coding.code",
+                    "id.value",
+                    "id",
                   ],
                   "lenient": true,
                   "query": "11111111-1111-1111-1111-111111111111",

--- a/src/elasticSearchService.ts
+++ b/src/elasticSearchService.ts
@@ -77,7 +77,7 @@ export class ElasticSearchService implements Search {
      * This parameter enables support for search parameters defined in Implementation Guides.
      * @param esClient
      * @param options.enableMultiTenancy - whether or not to enable multi-tenancy. When enabled a tenantId is required for all requests.
-     * @param options.useKeywordSubFields - whether or not to append `.keyword` to fields in search queries. You should enable this if you do dynamic mapping
+     * @param options.useKeywordSubFields - whether or not to append `.keyword` to fields in search queries. You should enable this if you do dynamic mapping. NOTE: Parameter`id` will not be affected by this due to it being of `keyword` type
      */
     constructor(
         searchFiltersForAllQueries: SearchFilter[] = [],

--- a/src/elasticSearchService.ts
+++ b/src/elasticSearchService.ts
@@ -77,7 +77,7 @@ export class ElasticSearchService implements Search {
      * This parameter enables support for search parameters defined in Implementation Guides.
      * @param esClient
      * @param options.enableMultiTenancy - whether or not to enable multi-tenancy. When enabled a tenantId is required for all requests.
-     * @param options.useKeywordSubFields - whether or not to append `.keyword` to fields in search queries. You should enable this if you do dynamic mapping. NOTE: Parameter`id` will not be affected by this due to it being of `keyword` type
+     * @param options.useKeywordSubFields - whether or not to append `.keyword` to fields in search queries. You should enable this if you do dynamic mapping. NOTE: Parameter`id` will not be affected by this due to it being of `keyword` type by default
      */
     constructor(
         searchFiltersForAllQueries: SearchFilter[] = [],


### PR DESCRIPTION
Description of changes:
Due to [previous change](https://github.com/awslabs/fhir-works-on-aws-search-es/pull/117) _id searches are not working since by default we [map `id` to be a keyword](https://github.com/awslabs/fhir-works-on-aws-persistence-ddb/blob/f9c9414a326f2e458b4e1c82ad29a694facee70e/src/ddbToEs/ddbToEsHelper.ts#L118-L119)

This change takes this into account and handles `id` as an exceptional case

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.