### PR TITLE
fix: update IG validation to reject reference params with no target

### DIFF
--- a/src/implementationGuides/__snapshots__/index.test.ts.snap
+++ b/src/implementationGuides/__snapshots__/index.test.ts.snap
@@ -369,7 +369,9 @@ Array [
     ],
     "description": "test",
     "name": "source-reference",
-    "target": undefined,
+    "target": Array [
+      "ValueSet",
+    ],
     "type": "reference",
     "url": "http://hl7.org/fhir/SearchParameter/Consent-source-reference",
   },

--- a/src/implementationGuides/index.test.ts
+++ b/src/implementationGuides/index.test.ts
@@ -237,4 +237,22 @@ describe('compile', () => {
         ]);
         await expect(compiled).rejects.toThrowError();
     });
+
+    test(`search param of type reference with empty target`, async () => {
+        const compiled = compile([
+            {
+                resourceType: 'SearchParameter',
+                url: 'http://hl7.org/fhir/SearchParameter/ConceptMap-source-uri',
+                name: 'source-uri',
+                code: 'source-uri',
+                type: 'reference',
+                description: 'The source value set that contains the concepts that are being mapped',
+                base: ['ConceptMap'],
+                expression: '(ConceptMap.source as uri)',
+                xpath: 'f:ConceptMap/f:sourceUri',
+                target: [],
+            },
+        ]);
+        await expect(compiled).rejects.toThrowError();
+    });
 });

--- a/src/implementationGuides/index.test.ts
+++ b/src/implementationGuides/index.test.ts
@@ -156,6 +156,7 @@ describe('compile', () => {
                 base: ['Consent'],
                 expression: 'Consent.source',
                 xpath: 'f:Consent/f:sourceAttachment | f:Consent/f:sourceReference',
+                target: ['ValueSet'],
             },
         ]);
         await expect(compiled).resolves.toMatchSnapshot();
@@ -216,6 +217,22 @@ describe('compile', () => {
                 base: ['Patient'],
                 expression: 'some random FHIRPath expression that cannot be parsed',
                 xpath: 'some random FHIRPath expression that cannot be parsed',
+            },
+        ]);
+        await expect(compiled).rejects.toThrowError();
+    });
+    test(`search param of type reference with no target`, async () => {
+        const compiled = compile([
+            {
+                resourceType: 'SearchParameter',
+                url: 'http://hl7.org/fhir/SearchParameter/ConceptMap-source-uri',
+                name: 'source-uri',
+                code: 'source-uri',
+                type: 'reference',
+                description: 'The source value set that contains the concepts that are being mapped',
+                base: ['ConceptMap'],
+                expression: '(ConceptMap.source as uri)',
+                xpath: 'f:ConceptMap/f:sourceUri',
             },
         ]);
         await expect(compiled).rejects.toThrowError();

--- a/src/implementationGuides/index.ts
+++ b/src/implementationGuides/index.ts
@@ -43,9 +43,23 @@ const isFhirSearchParam = (x: any): x is FhirSearchParam => {
         typeof x.type === 'string' &&
         (x.expression === undefined || typeof x.expression === 'string') &&
         (x.xpath === undefined || typeof x.xpath === 'string') &&
-        (x.target === undefined || (Array.isArray(x.target) && x.target.every((y: any) => typeof y === 'string'))) &&
-        (x.target === undefined ? x.type !== 'reference' : true)
+        (x.target === undefined || (Array.isArray(x.target) && x.target.every((y: any) => typeof y === 'string')))
     );
+};
+
+// validates any semantic necessities of FHIR Search Parameters
+const validateSearchParam = (param: FhirSearchParam) => {
+    if (param.type === 'reference') {
+        if (!param.target || param.target?.length === 0) {
+            throw new Error(
+                `Search Parameter of type reference must have a specified target. Error in ${JSON.stringify(
+                    param,
+                    null,
+                    2,
+                )}`,
+            );
+        }
+    }
 };
 
 const UNSUPPORTED_SEARCH_PARAMS = [
@@ -103,6 +117,7 @@ const compile = async (searchParams: any[]): Promise<any> => {
     const validFhirSearchParams: FhirSearchParam[] = [];
     searchParams.forEach(s => {
         if (isFhirSearchParam(s)) {
+            validateSearchParam(s);
             validFhirSearchParams.push(s);
         } else {
             throw new Error(`The following input is not a search parameter: ${JSON.stringify(s, null, 2)}`);

--- a/src/implementationGuides/index.ts
+++ b/src/implementationGuides/index.ts
@@ -43,7 +43,8 @@ const isFhirSearchParam = (x: any): x is FhirSearchParam => {
         typeof x.type === 'string' &&
         (x.expression === undefined || typeof x.expression === 'string') &&
         (x.xpath === undefined || typeof x.xpath === 'string') &&
-        (x.target === undefined || (Array.isArray(x.target) && x.target.every((y: any) => typeof y === 'string')))
+        (x.target === undefined || (Array.isArray(x.target) && x.target.every((y: any) => typeof y === 'string'))) &&
+        (x.target === undefined ? x.type !== 'reference' : true)
     );
 };
 


### PR DESCRIPTION
Issue #, if available:
[#449](https://github.com/awslabs/fhir-works-on-aws-deployment/issues/449)
Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.