### PR TITLE
feat: add class to aid in updating search mappings

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "nearley": "^2.20.0"
   },
   "devDependencies": {
+    "@elastic/elasticsearch-mock": "^0.3.1",
     "@types/flat": "^5.0.2",
     "@types/jest": "^26.0.19",
     "@types/lodash": "^4.14.161",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@
 export * from './elasticSearchService';
 export * from './implementationGuides';
 export * from './searchMappings';
+export * from './searchMappingsManager';

--- a/src/searchMappings/fhirTypeToESMapping.ts
+++ b/src/searchMappings/fhirTypeToESMapping.ts
@@ -4,8 +4,6 @@
  *
  */
 
-import { SearchField } from '../../scripts/elasticSearchMappingsGenerator/types';
-
 /** ************************************
  * Primitive Types
  ************************************ */
@@ -238,7 +236,10 @@ const fhirTypeMapping: Record<string, any> = {
 };
 
 // eslint-disable-next-line import/prefer-default-export
-export function fhirToESMapping(searchField: SearchField): { field: string; mapping: any } {
+export function fhirToESMapping(searchField: { field: string; type: string }): {
+    field: string;
+    mapping: any;
+} {
     if (!(searchField.type in fhirTypeMapping)) {
         throw new Error(`There is not a mapping available for the type: ${searchField.type}`);
     }

--- a/src/searchMappingsManager/index.test.ts
+++ b/src/searchMappingsManager/index.test.ts
@@ -1,0 +1,162 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { Client, errors } from '@elastic/elasticsearch';
+import SearchMock from '@elastic/elasticsearch-mock';
+import { SearchMappingsManager } from './index';
+
+const TEST_MAPPINGS = {
+    Patient: {
+        someField: {
+            type: 'text',
+        },
+    },
+    Practitioner: {
+        someField: {
+            type: 'keyword',
+        },
+    },
+};
+describe('SearchMappingsManager', () => {
+    let searchMock: SearchMock;
+    beforeEach(() => {
+        searchMock = new SearchMock();
+    });
+    afterEach(() => {
+        searchMock.clearAll();
+    });
+
+    test('should update all mappings', async () => {
+        const searchMappingsManager = new SearchMappingsManager({
+            numberOfShards: 3,
+            searchMappings: TEST_MAPPINGS,
+            searchClient: new Client({
+                node: 'https://fake-es-endpoint.com',
+                Connection: searchMock.getConnection(),
+            }),
+        });
+
+        const putMappingsMock = jest.fn(() => {
+            return { statusCode: 200, body: '' };
+        });
+
+        searchMock.add(
+            {
+                method: 'PUT',
+                path: '/:index/_mapping',
+            },
+            putMappingsMock,
+        );
+
+        await searchMappingsManager.createOrUpdateMappings();
+
+        expect(putMappingsMock.mock.calls).toMatchInlineSnapshot(`
+            Array [
+              Array [
+                Object {
+                  "body": Object {
+                    "someField": Object {
+                      "type": "text",
+                    },
+                  },
+                  "method": "PUT",
+                  "path": "/patient/_mapping",
+                  "querystring": Object {},
+                },
+              ],
+              Array [
+                Object {
+                  "body": Object {
+                    "someField": Object {
+                      "type": "keyword",
+                    },
+                  },
+                  "method": "PUT",
+                  "path": "/practitioner/_mapping",
+                  "querystring": Object {},
+                },
+              ],
+            ]
+        `);
+    });
+
+    test('should create indices if they do not exist', async () => {
+        const searchMappingsManager = new SearchMappingsManager({
+            numberOfShards: 3,
+            searchMappings: TEST_MAPPINGS,
+            searchClient: new Client({
+                node: 'https://fake-es-endpoint.com',
+                Connection: searchMock.getConnection(),
+            }),
+        });
+
+        searchMock.add(
+            {
+                method: 'PUT',
+                path: '/patient/_mapping',
+            },
+            () => {
+                // @ts-ignore
+                return new errors.ResponseError({
+                    headers: null,
+                    statusCode: 400,
+                    warnings: null,
+                    body: {
+                        error: {
+                            type: 'index_not_found_exception',
+                        },
+                    },
+                });
+            },
+        );
+
+        searchMock.add(
+            {
+                method: 'PUT',
+                path: '/practitioner/_mapping',
+            },
+            () => {
+                return { statusCode: 200, body: '' };
+            },
+        );
+
+        const createIndexMock = jest.fn(() => {
+            return { statusCode: 200 };
+        });
+
+        searchMock.add(
+            {
+                method: 'PUT',
+                path: '/patient',
+            },
+            createIndexMock,
+        );
+
+        await searchMappingsManager.createOrUpdateMappings();
+
+        expect(createIndexMock.mock.calls).toMatchInlineSnapshot(`
+            Array [
+              Array [
+                Object {
+                  "body": Object {
+                    "mappings": Object {
+                      "someField": Object {
+                        "type": "text",
+                      },
+                    },
+                    "settings": Object {
+                      "number_of_shards": 3,
+                    },
+                  },
+                  "method": "PUT",
+                  "path": "/patient",
+                  "querystring": Object {},
+                },
+              ],
+            ]
+        `);
+    });
+});

--- a/src/searchMappingsManager/index.test.ts
+++ b/src/searchMappingsManager/index.test.ts
@@ -45,6 +45,14 @@ describe('SearchMappingsManager', () => {
 
         searchMock.add(
             {
+                method: 'HEAD',
+                path: '/:index',
+            },
+            () => ({ statusCode: 200, body: true }),
+        );
+
+        searchMock.add(
+            {
                 method: 'PUT',
                 path: '/:index/_mapping',
             },
@@ -95,22 +103,29 @@ describe('SearchMappingsManager', () => {
 
         searchMock.add(
             {
-                method: 'PUT',
-                path: '/patient/_mapping',
+                method: 'HEAD',
+                path: '/patient',
             },
-            () => {
+            () =>
                 // @ts-ignore
-                return new errors.ResponseError({
+                new errors.ResponseError({
                     headers: null,
-                    statusCode: 400,
+                    statusCode: 404,
                     warnings: null,
                     body: {
                         error: {
                             type: 'index_not_found_exception',
                         },
                     },
-                });
+                }),
+        );
+
+        searchMock.add(
+            {
+                method: 'HEAD',
+                path: '/practitioner',
             },
+            () => ({ statusCode: 200, body: true }),
         );
 
         searchMock.add(

--- a/src/searchMappingsManager/index.ts
+++ b/src/searchMappingsManager/index.ts
@@ -1,0 +1,77 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { ResponseError } from '@elastic/elasticsearch/lib/errors';
+import { Client } from '@elastic/elasticsearch';
+import { ElasticSearch } from '../elasticSearch';
+
+const toIndexName = (resourceType: string) => resourceType.toLowerCase();
+
+// eslint-disable-next-line import/prefer-default-export
+export class SearchMappingsManager {
+    private readonly searchMappings: {
+        [resourceType: string]: any;
+    };
+
+    private readonly numberOfShards: number;
+
+    private readonly searchClient: Client;
+
+    constructor({
+        searchMappings,
+        numberOfShards,
+        searchClient = ElasticSearch,
+    }: {
+        searchMappings: { [resourceType: string]: any };
+        numberOfShards: number;
+        searchClient?: Client;
+    }) {
+        this.searchMappings = searchMappings;
+        this.numberOfShards = numberOfShards;
+        this.searchClient = searchClient;
+    }
+
+    /**
+     * Updates the mappings for all the FHIR resource types. If an index does not exist, it is created
+     */
+    async createOrUpdateMappings() {
+        const resourceTypesWithoutIndex: string[] = [];
+
+        // eslint-disable-next-line no-restricted-syntax
+        for (const [resourceType, mappings] of Object.entries(this.searchMappings)) {
+            console.log(`sending putMapping request for: ${resourceType}`);
+            try {
+                // eslint-disable-next-line no-await-in-loop
+                await this.searchClient.indices.put_mapping({
+                    index: toIndexName(resourceType),
+                    body: mappings,
+                });
+            } catch (error) {
+                if (error instanceof ResponseError && error.body.error.type === 'index_not_found_exception') {
+                    console.log(`index for ${resourceType} was not found. It will be created`);
+                    resourceTypesWithoutIndex.push(resourceType);
+                } else {
+                    throw error;
+                }
+            }
+        }
+
+        // eslint-disable-next-line no-restricted-syntax
+        for (const resourceType of resourceTypesWithoutIndex) {
+            console.log(`creating index for ${resourceType}`);
+            // eslint-disable-next-line no-await-in-loop
+            await this.searchClient.indices.create({
+                index: toIndexName(resourceType),
+                body: {
+                    mappings: this.searchMappings[resourceType],
+                    settings: {
+                        number_of_shards: this.numberOfShards,
+                    },
+                },
+            });
+        }
+    }
+}

--- a/src/searchMappingsManager/index.ts
+++ b/src/searchMappingsManager/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-await-in-loop,no-restricted-syntax */
 /*
  *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  SPDX-License-Identifier: Apache-2.0
@@ -20,6 +21,13 @@ export class SearchMappingsManager {
 
     private readonly searchClient: Client;
 
+    /**
+     * @param options
+     * @param options.searchMappings - search mappings for all FHIR resource types
+     * @param options.numberOfShards - number of shards for each new index created. See the documentation for guidance on how to choose the right number:
+     * https://docs.aws.amazon.com/opensearch-service/latest/developerguide/sizing-domains.html#bp-sharding
+     * @param options.searchClient - optionally provide your own search client instance
+     */
     constructor({
         searchMappings,
         numberOfShards,
@@ -38,40 +46,49 @@ export class SearchMappingsManager {
      * Updates the mappings for all the FHIR resource types. If an index does not exist, it is created
      */
     async createOrUpdateMappings() {
-        const resourceTypesWithoutIndex: string[] = [];
-
-        // eslint-disable-next-line no-restricted-syntax
+        const resourceTypesWithErrors = [];
         for (const [resourceType, mappings] of Object.entries(this.searchMappings)) {
-            console.log(`sending putMapping request for: ${resourceType}`);
             try {
-                // eslint-disable-next-line no-await-in-loop
-                await this.searchClient.indices.put_mapping({
-                    index: toIndexName(resourceType),
-                    body: mappings,
-                });
-            } catch (error) {
-                if (error instanceof ResponseError && error.body.error.type === 'index_not_found_exception') {
-                    console.log(`index for ${resourceType} was not found. It will be created`);
-                    resourceTypesWithoutIndex.push(resourceType);
-                } else {
-                    throw error;
+                try {
+                    await this.updateMapping(resourceType, mappings);
+                } catch (error) {
+                    if (error instanceof ResponseError && error.body.error.type === 'index_not_found_exception') {
+                        console.log(`index for ${resourceType} was not found. It will be created`);
+                        await this.createIndexWithMapping(resourceType, mappings);
+                    } else {
+                        throw error;
+                    }
                 }
+            } catch (e) {
+                console.log(e);
+                console.log(`Failed to update mapping for ${resourceType}:`, JSON.stringify(e, null, 2));
+                resourceTypesWithErrors.push(resourceType);
             }
         }
 
-        // eslint-disable-next-line no-restricted-syntax
-        for (const resourceType of resourceTypesWithoutIndex) {
-            console.log(`creating index for ${resourceType}`);
-            // eslint-disable-next-line no-await-in-loop
-            await this.searchClient.indices.create({
-                index: toIndexName(resourceType),
-                body: {
-                    mappings: this.searchMappings[resourceType],
-                    settings: {
-                        number_of_shards: this.numberOfShards,
-                    },
-                },
-            });
+        if (resourceTypesWithErrors.length > 0) {
+            throw new Error(`Failed to update mappings for: ${resourceTypesWithErrors}`);
         }
+    }
+
+    async updateMapping(resourceType: string, mapping: any) {
+        console.log(`sending putMapping request for: ${resourceType}`);
+        return this.searchClient.indices.put_mapping({
+            index: toIndexName(resourceType),
+            body: mapping,
+        });
+    }
+
+    async createIndexWithMapping(resourceType: string, mapping: any) {
+        console.log(`creating index for ${resourceType}`);
+        return this.searchClient.indices.create({
+            index: toIndexName(resourceType),
+            body: {
+                mappings: mapping,
+                settings: {
+                    number_of_shards: this.numberOfShards,
+                },
+            },
+        });
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -319,6 +319,15 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
+"@elastic/elasticsearch-mock@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch-mock/-/elasticsearch-mock-0.3.1.tgz#b84ab7034462d011378383b7460214b43270c669"
+  integrity sha512-ip+bsSxv0aE+P05be9bX4sWjQ37T61EcpMPsGJaGW07dSU+ERH4Q4Tq8kYSnFlUgpXZTf2nhtix+j/EOvZSXvQ==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    find-my-way "^4.3.3"
+    into-stream "^6.0.0"
+
 "@elastic/elasticsearch@7.13":
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/@elastic/elasticsearch/-/elasticsearch-7.13.0.tgz#6dcf511dfa91187e22c81e54f41f4bd0fd96b4d6"
@@ -1929,6 +1938,11 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+fast-decode-uri-component@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz#46f8b6c22b30ff7a81357d4f59abfae938202543"
+  integrity sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -2011,6 +2025,16 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+find-my-way@^4.3.3:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/find-my-way/-/find-my-way-4.3.3.tgz#2ab3880a03bcaa8594548d66b0cd1c5a6e98dd44"
+  integrity sha512-5E4bRdaATB1MewjOCBjx4xvD205a4t2ripCnXB+YFhYEJ0NABtrcC7XLXLq0TPoFe/WYGUFqys3Qk3HCOGeNcw==
+  dependencies:
+    fast-decode-uri-component "^1.0.1"
+    fast-deep-equal "^3.1.3"
+    safe-regex2 "^2.0.0"
+    semver-store "^0.3.0"
+
 find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
@@ -2069,6 +2093,14 @@ fragment-cache@^0.2.1:
   integrity sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=
   dependencies:
     map-cache "^0.2.2"
+
+from2@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"
+  integrity sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=
+  dependencies:
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2359,7 +2391,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2372,6 +2404,14 @@ internal-slot@^1.0.3:
     get-intrinsic "^1.1.0"
     has "^1.0.3"
     side-channel "^1.0.4"
+
+into-stream@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-6.0.0.tgz#4bfc1244c0128224e18b8870e85b2de8e66c6702"
+  integrity sha512-XHbaOAvP+uFKUFsOgoNPRjLkwB+I22JFPFe5OjTkQ0nwgj6+pSjb4NmB6VMxaPshLiOf+zcpOCBQuLwC1KHhZA==
+  dependencies:
+    from2 "^2.3.0"
+    p-is-promise "^3.0.0"
 
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
@@ -3638,6 +3678,11 @@ p-finally@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
 
+p-is-promise@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-3.0.0.tgz#58e78c7dfe2e163cf2a04ff869e7c1dba64a5971"
+  integrity sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==
+
 p-limit@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
@@ -3938,7 +3983,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-readable-stream@^2.3.7:
+readable-stream@^2.0.0, readable-stream@^2.3.7:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -4038,6 +4083,11 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
+ret@~0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.2.2.tgz#b6861782a1f4762dce43402a71eb7a283f44573c"
+  integrity sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==
+
 reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
@@ -4071,6 +4121,13 @@ safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safe-regex2@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/safe-regex2/-/safe-regex2-2.0.0.tgz#b287524c397c7a2994470367e0185e1916b1f5b9"
+  integrity sha512-PaUSFsUaNNuKwkBijoAPHAK6/eM6VirvyPWlZ7BAQy4D+hCvh4B6lIG+nPdhbFfIbP+gTGBcrdsOaUs0F+ZBOQ==
+  dependencies:
+    ret "~0.2.0"
 
 safe-regex@^1.1.0:
   version "1.1.0"
@@ -4125,6 +4182,11 @@ secure-json-parse@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/secure-json-parse/-/secure-json-parse-2.4.0.tgz#5aaeaaef85c7a417f76271a4f5b0cc3315ddca85"
   integrity sha512-Q5Z/97nbON5t/L/sH6mY2EacfjVGwrCcSi5D3btRO2GZ8pf1K1UN7Z9H5J57hjVU2Qzxr1xO+FmBhOvEkzCMmg==
+
+semver-store@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/semver-store/-/semver-store-0.3.0.tgz#ce602ff07df37080ec9f4fb40b29576547befbe9"
+  integrity sha512-TcZvGMMy9vodEFSse30lWinkj+JgOBvPn8wRItpQRSayhc+4ssDs335uklkfvQQJgL/WvmHLVj4Ycv2s7QCQMg==
 
 "semver@2 || 3 || 4 || 5", semver@^5.5.0:
   version "5.7.1"


### PR DESCRIPTION
Add `SearchMappingsManager` class that will be used by a custom resource to update the search mappings for all FHIR resource types.

Related PR:
- https://github.com/awslabs/fhir-works-on-aws-deployment/pull/474

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.