### PR TITLE
fix: chained parameters with zero matches returns empty

### DIFF
--- a/src/QueryBuilder/chain.ts
+++ b/src/QueryBuilder/chain.ts
@@ -4,7 +4,7 @@ import { FHIRSearchParametersRegistry } from '../FHIRSearchParametersRegistry';
 import { NON_SEARCHABLE_PARAMETERS } from '../constants';
 import { parseSearchModifiers, normalizeQueryParams, isChainedParameter } from './util';
 
-interface ChainParameter {
+export interface ChainParameter {
     chain: { resourceType: string; searchParam: string }[];
     initialValue: string[];
 }

--- a/src/__snapshots__/elasticSearchService.test.ts.snap
+++ b/src/__snapshots__/elasticSearchService.test.ts.snap
@@ -2148,6 +2148,259 @@ Array [
 ]
 `;
 
+exports[`typeSearch query snapshots for chained queryParams with no matches queryParams={"general-practitioner:PractitionerRole.location:Location.address-city":"pwoiejfpow","organization.name":"wefgw"} 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "_source": false,
+        "fields": Array [
+          "id",
+        ],
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [
+              Object {
+                "multi_match": Object {
+                  "fields": Array [
+                    "address.city",
+                    "address.city.*",
+                  ],
+                  "lenient": true,
+                  "query": "pwoiejfpow",
+                },
+              },
+            ],
+          },
+        },
+      },
+      "index": "location-alias",
+      "size": 100,
+      "track_total_hits": true,
+    },
+  ],
+  Array [
+    Object {
+      "body": Object {
+        "_source": false,
+        "fields": Array [
+          "id",
+        ],
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [
+              Object {
+                "bool": Object {
+                  "should": Array [
+                    Object {
+                      "multi_match": Object {
+                        "fields": Array [
+                          "name",
+                          "name.*",
+                        ],
+                        "lenient": true,
+                        "query": "wefgw",
+                      },
+                    },
+                    Object {
+                      "multi_match": Object {
+                        "fields": Array [
+                          "alias",
+                          "alias.*",
+                        ],
+                        "lenient": true,
+                        "query": "wefgw",
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+      "index": "organization-alias",
+      "size": 100,
+      "track_total_hits": true,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch query snapshots for chained queryParams with no matches queryParams={"general-practitioner:PractitionerRole.location:Location.address-city":"wefw"} 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "_source": false,
+        "fields": Array [
+          "id",
+        ],
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [
+              Object {
+                "multi_match": Object {
+                  "fields": Array [
+                    "address.city",
+                    "address.city.*",
+                  ],
+                  "lenient": true,
+                  "query": "wefw",
+                },
+              },
+            ],
+          },
+        },
+      },
+      "index": "location-alias",
+      "size": 100,
+      "track_total_hits": true,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch query snapshots for chained queryParams with no matches queryParams={"link:Patient.birthdate":"ge2020-01-01","link:Patient.organization.name":"opwijeow"} 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "_source": false,
+        "fields": Array [
+          "id",
+        ],
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [
+              Object {
+                "bool": Object {
+                  "should": Array [
+                    Object {
+                      "range": Object {
+                        "birthDate": Object {
+                          "gte": 2020-01-01T00:00:00.000Z,
+                        },
+                      },
+                    },
+                    Object {
+                      "bool": Object {
+                        "must": Array [
+                          Object {
+                            "exists": Object {
+                              "field": "birthDate.start",
+                            },
+                          },
+                          Object {
+                            "exists": Object {
+                              "field": "birthDate.end",
+                            },
+                          },
+                          Object {
+                            "range": Object {
+                              "birthDate.end": Object {
+                                "gte": 2020-01-01T00:00:00.000Z,
+                              },
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+      "index": "patient-alias",
+      "size": 100,
+      "track_total_hits": true,
+    },
+  ],
+  Array [
+    Object {
+      "body": Object {
+        "_source": false,
+        "fields": Array [
+          "id",
+        ],
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [
+              Object {
+                "bool": Object {
+                  "should": Array [
+                    Object {
+                      "multi_match": Object {
+                        "fields": Array [
+                          "name",
+                          "name.*",
+                        ],
+                        "lenient": true,
+                        "query": "opwijeow",
+                      },
+                    },
+                    Object {
+                      "multi_match": Object {
+                        "fields": Array [
+                          "alias",
+                          "alias.*",
+                        ],
+                        "lenient": true,
+                        "query": "opwijeow",
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+      "index": "organization-alias",
+      "size": 100,
+      "track_total_hits": true,
+    },
+  ],
+]
+`;
+
 exports[`typeSearch query snapshots for chained queryParams, multi-tenancy enabled queryParams={"general-practitioner:PractitionerRole.location:Location.address-city":"Washington"} 1`] = `
 Array [
   Array [
@@ -2392,418 +2645,6 @@ Array [
               },
             ],
             "must": Array [],
-          },
-        },
-      },
-      "from": 0,
-      "index": "patient-alias",
-      "size": 20,
-      "track_total_hits": true,
-    },
-  ],
-]
-`;
-
-exports[`typeSearch query snapshots for nonsense chained queryParams queryParams={"general-practitioner:PractitionerRole.location:Location.address-city":"pwoiejfpow","organization.name":"wefgw"} 1`] = `
-Array [
-  Array [
-    Object {
-      "body": Object {
-        "_source": false,
-        "fields": Array [
-          "id",
-        ],
-        "query": Object {
-          "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
-            "must": Array [
-              Object {
-                "multi_match": Object {
-                  "fields": Array [
-                    "address.city",
-                    "address.city.*",
-                  ],
-                  "lenient": true,
-                  "query": "pwoiejfpow",
-                },
-              },
-            ],
-          },
-        },
-      },
-      "index": "location-alias",
-      "size": 100,
-      "track_total_hits": true,
-    },
-  ],
-  Array [
-    Object {
-      "body": Object {
-        "_source": false,
-        "fields": Array [
-          "id",
-        ],
-        "query": Object {
-          "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
-            "must": Array [],
-          },
-        },
-      },
-      "index": "practitionerrole-alias",
-      "size": 100,
-      "track_total_hits": true,
-    },
-  ],
-  Array [
-    Object {
-      "body": Object {
-        "_source": false,
-        "fields": Array [
-          "id",
-        ],
-        "query": Object {
-          "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
-            "must": Array [
-              Object {
-                "bool": Object {
-                  "should": Array [
-                    Object {
-                      "multi_match": Object {
-                        "fields": Array [
-                          "name",
-                          "name.*",
-                        ],
-                        "lenient": true,
-                        "query": "wefgw",
-                      },
-                    },
-                    Object {
-                      "multi_match": Object {
-                        "fields": Array [
-                          "alias",
-                          "alias.*",
-                        ],
-                        "lenient": true,
-                        "query": "wefgw",
-                      },
-                    },
-                  ],
-                },
-              },
-            ],
-          },
-        },
-      },
-      "index": "organization-alias",
-      "size": 100,
-      "track_total_hits": true,
-    },
-  ],
-  Array [
-    Object {
-      "body": Object {
-        "query": Object {
-          "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
-            "must": Array [
-              Object {
-                "bool": Object {
-                  "should": Array [],
-                },
-              },
-            ],
-          },
-        },
-      },
-      "from": 0,
-      "index": "patient-alias",
-      "size": 20,
-      "track_total_hits": true,
-    },
-  ],
-]
-`;
-
-exports[`typeSearch query snapshots for nonsense chained queryParams queryParams={"general-practitioner:PractitionerRole.location:Location.address-city":"wefw"} 1`] = `
-Array [
-  Array [
-    Object {
-      "body": Object {
-        "_source": false,
-        "fields": Array [
-          "id",
-        ],
-        "query": Object {
-          "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
-            "must": Array [
-              Object {
-                "multi_match": Object {
-                  "fields": Array [
-                    "address.city",
-                    "address.city.*",
-                  ],
-                  "lenient": true,
-                  "query": "wefw",
-                },
-              },
-            ],
-          },
-        },
-      },
-      "index": "location-alias",
-      "size": 100,
-      "track_total_hits": true,
-    },
-  ],
-  Array [
-    Object {
-      "body": Object {
-        "_source": false,
-        "fields": Array [
-          "id",
-        ],
-        "query": Object {
-          "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
-            "must": Array [],
-          },
-        },
-      },
-      "index": "practitionerrole-alias",
-      "size": 100,
-      "track_total_hits": true,
-    },
-  ],
-  Array [
-    Object {
-      "body": Object {
-        "query": Object {
-          "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
-            "must": Array [
-              Object {
-                "bool": Object {
-                  "should": Array [],
-                },
-              },
-            ],
-          },
-        },
-      },
-      "from": 0,
-      "index": "patient-alias",
-      "size": 20,
-      "track_total_hits": true,
-    },
-  ],
-]
-`;
-
-exports[`typeSearch query snapshots for nonsense chained queryParams queryParams={"link:Patient.birthdate":"ge2020-01-01","link:Patient.organization.name":"opwijeow"} 1`] = `
-Array [
-  Array [
-    Object {
-      "body": Object {
-        "_source": false,
-        "fields": Array [
-          "id",
-        ],
-        "query": Object {
-          "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
-            "must": Array [
-              Object {
-                "bool": Object {
-                  "should": Array [
-                    Object {
-                      "range": Object {
-                        "birthDate": Object {
-                          "gte": 2020-01-01T00:00:00.000Z,
-                        },
-                      },
-                    },
-                    Object {
-                      "bool": Object {
-                        "must": Array [
-                          Object {
-                            "exists": Object {
-                              "field": "birthDate.start",
-                            },
-                          },
-                          Object {
-                            "exists": Object {
-                              "field": "birthDate.end",
-                            },
-                          },
-                          Object {
-                            "range": Object {
-                              "birthDate.end": Object {
-                                "gte": 2020-01-01T00:00:00.000Z,
-                              },
-                            },
-                          },
-                        ],
-                      },
-                    },
-                  ],
-                },
-              },
-            ],
-          },
-        },
-      },
-      "index": "patient-alias",
-      "size": 100,
-      "track_total_hits": true,
-    },
-  ],
-  Array [
-    Object {
-      "body": Object {
-        "_source": false,
-        "fields": Array [
-          "id",
-        ],
-        "query": Object {
-          "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
-            "must": Array [
-              Object {
-                "bool": Object {
-                  "should": Array [
-                    Object {
-                      "multi_match": Object {
-                        "fields": Array [
-                          "name",
-                          "name.*",
-                        ],
-                        "lenient": true,
-                        "query": "opwijeow",
-                      },
-                    },
-                    Object {
-                      "multi_match": Object {
-                        "fields": Array [
-                          "alias",
-                          "alias.*",
-                        ],
-                        "lenient": true,
-                        "query": "opwijeow",
-                      },
-                    },
-                  ],
-                },
-              },
-            ],
-          },
-        },
-      },
-      "index": "organization-alias",
-      "size": 100,
-      "track_total_hits": true,
-    },
-  ],
-  Array [
-    Object {
-      "body": Object {
-        "_source": false,
-        "fields": Array [
-          "id",
-        ],
-        "query": Object {
-          "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
-            "must": Array [],
-          },
-        },
-      },
-      "index": "patient-alias",
-      "size": 100,
-      "track_total_hits": true,
-    },
-  ],
-  Array [
-    Object {
-      "body": Object {
-        "query": Object {
-          "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
-            "must": Array [
-              Object {
-                "bool": Object {
-                  "should": Array [],
-                },
-              },
-            ],
           },
         },
       },

--- a/src/__snapshots__/elasticSearchService.test.ts.snap
+++ b/src/__snapshots__/elasticSearchService.test.ts.snap
@@ -2404,6 +2404,418 @@ Array [
 ]
 `;
 
+exports[`typeSearch query snapshots for nonsense chained queryParams queryParams={"general-practitioner:PractitionerRole.location:Location.address-city":"pwoiejfpow","organization.name":"wefgw"} 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "_source": false,
+        "fields": Array [
+          "id",
+        ],
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [
+              Object {
+                "multi_match": Object {
+                  "fields": Array [
+                    "address.city",
+                    "address.city.*",
+                  ],
+                  "lenient": true,
+                  "query": "pwoiejfpow",
+                },
+              },
+            ],
+          },
+        },
+      },
+      "index": "location-alias",
+      "size": 100,
+      "track_total_hits": true,
+    },
+  ],
+  Array [
+    Object {
+      "body": Object {
+        "_source": false,
+        "fields": Array [
+          "id",
+        ],
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [],
+          },
+        },
+      },
+      "index": "practitionerrole-alias",
+      "size": 100,
+      "track_total_hits": true,
+    },
+  ],
+  Array [
+    Object {
+      "body": Object {
+        "_source": false,
+        "fields": Array [
+          "id",
+        ],
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [
+              Object {
+                "bool": Object {
+                  "should": Array [
+                    Object {
+                      "multi_match": Object {
+                        "fields": Array [
+                          "name",
+                          "name.*",
+                        ],
+                        "lenient": true,
+                        "query": "wefgw",
+                      },
+                    },
+                    Object {
+                      "multi_match": Object {
+                        "fields": Array [
+                          "alias",
+                          "alias.*",
+                        ],
+                        "lenient": true,
+                        "query": "wefgw",
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+      "index": "organization-alias",
+      "size": 100,
+      "track_total_hits": true,
+    },
+  ],
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [
+              Object {
+                "bool": Object {
+                  "should": Array [],
+                },
+              },
+            ],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient-alias",
+      "size": 20,
+      "track_total_hits": true,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch query snapshots for nonsense chained queryParams queryParams={"general-practitioner:PractitionerRole.location:Location.address-city":"wefw"} 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "_source": false,
+        "fields": Array [
+          "id",
+        ],
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [
+              Object {
+                "multi_match": Object {
+                  "fields": Array [
+                    "address.city",
+                    "address.city.*",
+                  ],
+                  "lenient": true,
+                  "query": "wefw",
+                },
+              },
+            ],
+          },
+        },
+      },
+      "index": "location-alias",
+      "size": 100,
+      "track_total_hits": true,
+    },
+  ],
+  Array [
+    Object {
+      "body": Object {
+        "_source": false,
+        "fields": Array [
+          "id",
+        ],
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [],
+          },
+        },
+      },
+      "index": "practitionerrole-alias",
+      "size": 100,
+      "track_total_hits": true,
+    },
+  ],
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [
+              Object {
+                "bool": Object {
+                  "should": Array [],
+                },
+              },
+            ],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient-alias",
+      "size": 20,
+      "track_total_hits": true,
+    },
+  ],
+]
+`;
+
+exports[`typeSearch query snapshots for nonsense chained queryParams queryParams={"link:Patient.birthdate":"ge2020-01-01","link:Patient.organization.name":"opwijeow"} 1`] = `
+Array [
+  Array [
+    Object {
+      "body": Object {
+        "_source": false,
+        "fields": Array [
+          "id",
+        ],
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [
+              Object {
+                "bool": Object {
+                  "should": Array [
+                    Object {
+                      "range": Object {
+                        "birthDate": Object {
+                          "gte": 2020-01-01T00:00:00.000Z,
+                        },
+                      },
+                    },
+                    Object {
+                      "bool": Object {
+                        "must": Array [
+                          Object {
+                            "exists": Object {
+                              "field": "birthDate.start",
+                            },
+                          },
+                          Object {
+                            "exists": Object {
+                              "field": "birthDate.end",
+                            },
+                          },
+                          Object {
+                            "range": Object {
+                              "birthDate.end": Object {
+                                "gte": 2020-01-01T00:00:00.000Z,
+                              },
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+      "index": "patient-alias",
+      "size": 100,
+      "track_total_hits": true,
+    },
+  ],
+  Array [
+    Object {
+      "body": Object {
+        "_source": false,
+        "fields": Array [
+          "id",
+        ],
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [
+              Object {
+                "bool": Object {
+                  "should": Array [
+                    Object {
+                      "multi_match": Object {
+                        "fields": Array [
+                          "name",
+                          "name.*",
+                        ],
+                        "lenient": true,
+                        "query": "opwijeow",
+                      },
+                    },
+                    Object {
+                      "multi_match": Object {
+                        "fields": Array [
+                          "alias",
+                          "alias.*",
+                        ],
+                        "lenient": true,
+                        "query": "opwijeow",
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+      "index": "organization-alias",
+      "size": 100,
+      "track_total_hits": true,
+    },
+  ],
+  Array [
+    Object {
+      "body": Object {
+        "_source": false,
+        "fields": Array [
+          "id",
+        ],
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [],
+          },
+        },
+      },
+      "index": "patient-alias",
+      "size": 100,
+      "track_total_hits": true,
+    },
+  ],
+  Array [
+    Object {
+      "body": Object {
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "match": Object {
+                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
+                },
+              },
+            ],
+            "must": Array [
+              Object {
+                "bool": Object {
+                  "should": Array [],
+                },
+              },
+            ],
+          },
+        },
+      },
+      "from": 0,
+      "index": "patient-alias",
+      "size": 20,
+      "track_total_hits": true,
+    },
+  ],
+]
+`;
+
 exports[`typeSearch query snapshots for simple queryParams; with ACTIVE filter queryParams={"_count":"10","_getpagesoffset":"2","_id":"11111111-1111-1111-1111-111111111111","gender":"female","name":"Emily","_format":"json"} 1`] = `
 Array [
   Array [

--- a/src/elasticSearchService.test.ts
+++ b/src/elasticSearchService.test.ts
@@ -1138,7 +1138,7 @@ describe('typeSearch', () => {
         });
     });
 
-    describe('query snapshots for nonsense chained queryParams', () => {
+    describe('query snapshots for chained queryParams with no matches', () => {
         each([
             [{ 'general-practitioner:PractitionerRole.location:Location.address-city': 'wefw' }],
             [
@@ -1153,7 +1153,7 @@ describe('typeSearch', () => {
                 body: {
                     hits: {
                         total: {
-                            value: 1,
+                            value: 0,
                             relation: 'eq',
                         },
                         max_score: 0,

--- a/src/elasticSearchService.test.ts
+++ b/src/elasticSearchService.test.ts
@@ -1137,4 +1137,40 @@ describe('typeSearch', () => {
             ).rejects.toThrowError(InvalidSearchParameterError);
         });
     });
+
+    describe('query snapshots for nonsense chained queryParams', () => {
+        each([
+            [{ 'general-practitioner:PractitionerRole.location:Location.address-city': 'wefw' }],
+            [
+                {
+                    'general-practitioner:PractitionerRole.location:Location.address-city': 'pwoiejfpow',
+                    'organization.name': 'wefgw',
+                },
+            ],
+            [{ 'link:Patient.birthdate': 'ge2020-01-01', 'link:Patient.organization.name': 'opwijeow' }],
+        ]).test('queryParams=%j', async (queryParams: any) => {
+            const fakeSearchResult = {
+                body: {
+                    hits: {
+                        total: {
+                            value: 1,
+                            relation: 'eq',
+                        },
+                        max_score: 0,
+                        hits: [],
+                    },
+                },
+            };
+            (ElasticSearch.search as jest.Mock).mockResolvedValue(fakeSearchResult);
+            const es = new ElasticSearchService(FILTER_RULES_FOR_ACTIVE_RESOURCES);
+            await es.typeSearch({
+                resourceType: 'Patient',
+                baseUrl: 'https://base-url.com',
+                queryParams,
+                allowedResourceTypes: ALLOWED_RESOURCE_TYPES,
+            });
+
+            expect((ElasticSearch.search as jest.Mock).mock.calls).toMatchSnapshot();
+        });
+    });
 });

--- a/src/elasticSearchService.ts
+++ b/src/elasticSearchService.ts
@@ -7,7 +7,7 @@
 import URL from 'url';
 
 import { ResponseError } from '@elastic/elasticsearch/lib/errors';
-import { partition, merge } from 'lodash';
+import { partition, merge, isEmpty } from 'lodash';
 import {
     Search,
     TypeSearchRequest,
@@ -32,7 +32,7 @@ import {
 import { buildIncludeQueries, buildRevIncludeQueries } from './searchInclusions';
 import { FHIRSearchParametersRegistry } from './FHIRSearchParametersRegistry';
 import { buildQueryForAllSearchParameters, buildSortClause } from './QueryBuilder';
-import parseChainedParameters from './QueryBuilder/chain';
+import parseChainedParameters, { ChainParameter } from './QueryBuilder/chain';
 import getComponentLogger from './loggerBuilder';
 
 export type Query = {
@@ -161,8 +161,25 @@ export class ElasticSearchService implements Search {
             }
 
             const filter = this.getFilters(request);
-
-            const chainedParameterQuery = await this.getChainedParametersQuery(request, filter);
+            const parsedChainParameters = parseChainedParameters(
+                this.fhirSearchParametersRegistry,
+                request.resourceType,
+                request.queryParams,
+            );
+            let chainedParameterQuery;
+            if (parsedChainParameters.length > 0) {
+                chainedParameterQuery = await this.getChainedParametersQuery(parsedChainParameters, request, filter);
+                if (isEmpty(chainedParameterQuery)) {
+                    // chained parameter query did not return any results
+                    return {
+                        result: {
+                            numberOfResults: 0,
+                            entries: [],
+                            message: '',
+                        },
+                    };
+                }
+            }
 
             const query = buildQueryForAllSearchParameters(
                 this.fhirSearchParametersRegistry,
@@ -236,15 +253,15 @@ export class ElasticSearchService implements Search {
 
     // Return translated chained parameters that can be used as normal search parameters
     // eslint-disable-next-line class-methods-use-this
-    private async getChainedParametersQuery(request: TypeSearchRequest, filters: any[] = []): Promise<{}> {
+    private async getChainedParametersQuery(
+        parsedChainParameters: ChainParameter[],
+        request: TypeSearchRequest,
+        filters: any[] = [],
+    ): Promise<{}> {
         let combinedChainedParameters = {};
 
         // eslint-disable-next-line no-restricted-syntax
-        for (const { chain, initialValue } of parseChainedParameters(
-            this.fhirSearchParametersRegistry,
-            request.resourceType,
-            request.queryParams,
-        )) {
+        for (const { chain, initialValue } of parsedChainParameters) {
             let stepValue = initialValue;
             let chainComplete = true;
             const lastChain: { resourceType: string; searchParam: string } = chain.pop()!;

--- a/src/elasticSearchService.ts
+++ b/src/elasticSearchService.ts
@@ -321,7 +321,6 @@ export class ElasticSearchService implements Search {
                 index: getAliasName(searchQuery.resourceType, request.tenantId),
                 ...(request.sessionId && { preference: request.sessionId }),
             };
-
             if (logger.isDebugEnabled()) {
                 logger.debug(`Elastic search query: ${JSON.stringify(searchQueryWithAlias, null, 2)}`);
             }
@@ -332,9 +331,12 @@ export class ElasticSearchService implements Search {
             };
         } catch (error) {
             // Indexes are created the first time a resource of a given type is written to DDB.
-            if (error instanceof ResponseError && error.message === 'index_not_found_exception') {
+            if (error instanceof ResponseError && error.meta.body.error.type === 'index_not_found_exception') {
                 logger.info(
-                    `Search index for ${searchQuery.queryRequest.index} does not exist. Returning an empty search result`,
+                    `Search index for ${getAliasName(
+                        searchQuery.resourceType,
+                        request.tenantId,
+                    )} does not exist. Returning an empty search result`,
                 );
                 return {
                     total: 0,


### PR DESCRIPTION
Issue #138, if available:

Description of changes:
Update chain param search to no longer return all resources when presented with a nonsense search parameter.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.