### PR TITLE
chore: fix workflow condition

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -7,11 +7,11 @@ jobs:
   tag-release:
     name: Create release PR
     runs-on: ubuntu-18.04
-    if: >
-      ${{ startsWith(github.event.head_commit.message, 'feat') ||
+    if: |
+      startsWith(github.event.head_commit.message, 'feat') ||
       startsWith(github.event.head_commit.message, 'fix') ||
       contains(github.event.head_commit.message, 'BREAKING_CHANGE') ||
-      contains(github.event.head_commit.message, '!')}}
+      contains(github.event.head_commit.message, '!')
     steps:
       - uses: actions/checkout@v2.3.4
         with:


### PR DESCRIPTION
Issue #, if available:

Description of changes:

* Update syntax of multi-line if condition in GitHub workflow
* Tested chore: commit does not trigger workflow: https://github.com/Bingjiling/fhir-works-on-aws-search-es/actions/runs/1492095766
* Tested fix: commit trigger workflow: https://github.com/Bingjiling/fhir-works-on-aws-search-es/actions/runs/1492126229  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.