### PR TITLE
refactor: add chained and inclusion params to parser

### DIFF
--- a/src/FhirQueryParser/index.test.ts
+++ b/src/FhirQueryParser/index.test.ts
@@ -328,4 +328,63 @@ describe('queryParser', () => {
             }
         `);
     });
+
+    test('chained params', () => {
+        const q = parseQuery(fhirSearchParametersRegistry, 'DiagnosticReport', {
+            'subject.name': 'DiagnosticReport?subject.name=peter',
+        });
+        expect(q).toMatchInlineSnapshot(`
+            Object {
+              "chainedSearchParams": Object {
+                "subject.name": Array [
+                  "DiagnosticReport?subject.name=peter",
+                ],
+              },
+              "resourceType": "DiagnosticReport",
+              "searchParams": Array [],
+            }
+        `);
+    });
+
+    test('inclusion params', () => {
+        const q = parseQuery(fhirSearchParametersRegistry, 'MedicationRequest', {
+            _include: 'MedicationRequest:patient',
+            _revinclude: 'Provenance:target',
+        });
+        expect(q).toMatchInlineSnapshot(`
+            Object {
+              "inclusionSearchParams": Object {
+                "_include": Array [
+                  "MedicationRequest:patient",
+                ],
+                "_revinclude": Array [
+                  "Provenance:target",
+                ],
+              },
+              "resourceType": "MedicationRequest",
+              "searchParams": Array [],
+            }
+        `);
+    });
+
+    test('other params', () => {
+        const q = parseQuery(fhirSearchParametersRegistry, 'Patient', {
+            _count: '10',
+            _sort: '_lastUpdated',
+        });
+        expect(q).toMatchInlineSnapshot(`
+            Object {
+              "otherParams": Object {
+                "_count": Array [
+                  "10",
+                ],
+                "_sort": Array [
+                  "_lastUpdated",
+                ],
+              },
+              "resourceType": "Patient",
+              "searchParams": Array [],
+            }
+        `);
+    });
 });

--- a/src/FhirQueryParser/index.ts
+++ b/src/FhirQueryParser/index.ts
@@ -5,9 +5,10 @@
  */
 
 import { InvalidSearchParameterError } from 'fhir-works-on-aws-interface';
+import { isEmpty } from 'lodash';
 import { FHIRSearchParametersRegistry, SearchParam } from '../FHIRSearchParametersRegistry';
 import { isChainedParameter, normalizeQueryParams, parseSearchModifiers } from './util';
-import { NON_SEARCHABLE_PARAMETERS } from '../constants';
+import { INCLUSION_PARAMETERS, NON_SEARCHABLE_PARAMETERS } from '../constants';
 import getOrSearchValues from './searchOR';
 import { DateSearchValue, parseDateSearchValue } from './typeParsers/dateParser';
 import { parseTokenSearchValue, TokenSearchValue } from './typeParsers/tokenParser';
@@ -83,6 +84,9 @@ export type QueryParam =
 export interface ParsedFhirQueryParams {
     resourceType: string;
     searchParams: QueryParam[];
+    inclusionSearchParams?: { [name: string]: string[] };
+    chainedSearchParams?: { [name: string]: string[] };
+    otherParams?: { [name: string]: string[] };
 }
 
 const parseStringLikeSearchValue = (rawSearchValue: string): StringLikeSearchValue => rawSearchValue;
@@ -175,10 +179,30 @@ export const parseQuery = (
 ): ParsedFhirQueryParams => {
     const normalizedQueryParams: { [name: string]: string[] } = normalizeQueryParams(queryParams);
 
+    const inclusionSearchParams: { [name: string]: string[] } = {};
+    const chainedSearchParams: { [name: string]: string[] } = {};
+    const otherParams: { [name: string]: string[] } = {};
+
     const searchableParams: [string, string[]][] = Object.entries(normalizedQueryParams).filter(
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        ([searchParameter, value]) =>
-            !NON_SEARCHABLE_PARAMETERS.includes(searchParameter) && !isChainedParameter(searchParameter),
+        ([searchParameter, value]) => {
+            if (isChainedParameter(searchParameter)) {
+                chainedSearchParams[searchParameter] = value;
+                return false;
+            }
+
+            if (INCLUSION_PARAMETERS.includes(searchParameter)) {
+                inclusionSearchParams[searchParameter] = value;
+                return false;
+            }
+
+            if (NON_SEARCHABLE_PARAMETERS.includes(searchParameter)) {
+                otherParams[searchParameter] = value;
+                return false;
+            }
+
+            return true;
+        },
     );
 
     const parsedParams = searchableParams.flatMap(([searchParameter, searchValues]) => {
@@ -202,5 +226,8 @@ export const parseQuery = (
     return {
         resourceType,
         searchParams: parsedParams,
+        ...(!isEmpty(inclusionSearchParams) && { inclusionSearchParams }),
+        ...(!isEmpty(chainedSearchParams) && { chainedSearchParams }),
+        ...(!isEmpty(otherParams) && { otherParams }),
     };
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,15 +12,14 @@ export const enum SEARCH_PAGINATION_PARAMS {
 
 export const SEPARATOR: string = '_';
 export const ITERATIVE_INCLUSION_PARAMETERS = ['_include:iterate', '_revinclude:iterate'];
+export const INCLUSION_PARAMETERS = ['_include', '_revinclude', ...ITERATIVE_INCLUSION_PARAMETERS];
 export const SORT_PARAMETER = '_sort';
 export const NON_SEARCHABLE_PARAMETERS = [
     SORT_PARAMETER,
     SEARCH_PAGINATION_PARAMS.PAGES_OFFSET,
     SEARCH_PAGINATION_PARAMS.COUNT,
     '_format',
-    '_include',
-    '_revinclude',
-    ...ITERATIVE_INCLUSION_PARAMETERS,
+    ...INCLUSION_PARAMETERS,
 ];
 
 export const MAX_ES_WINDOW_SIZE: number = 10000;


### PR DESCRIPTION
It's better for the parser to report include/revinclude, chained params, etc. instead of silently dropping them.

Eventually we could consolidate all the parsing here (e.g. move [parseChainedParameters](https://github.com/awslabs/fhir-works-on-aws-search-es/blob/3a134092705ef9a44db8feaea58dd2d00d854f20/src/QueryBuilder/chain.ts#L12) here), but right now the parser just reports a list of the include/revinclude, chained params, and other non searchable params.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.