### PR TITLE
feat: add InMemoryMatcher with date and number matching

### DIFF
--- a/src/InMemoryMatcher/index.test.ts
+++ b/src/InMemoryMatcher/index.test.ts
@@ -1,0 +1,246 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { matchParsedFhirQueryParams } from './index';
+import { ParsedFhirQueryParams } from '../FhirQueryParser';
+import { FHIRSearchParametersRegistry, SearchParam } from '../FHIRSearchParametersRegistry';
+
+const fhirSearchParametersRegistry = new FHIRSearchParametersRegistry('4.0.1');
+const givenParam = fhirSearchParametersRegistry.getSearchParameter('Patient', 'given')!;
+const familyParam = fhirSearchParametersRegistry.getSearchParameter('Patient', 'family')!;
+
+describe('evaluateParsedFhirQueryParams', () => {
+    test('resourceType mismatch', () => {
+        const resource = {
+            resourceType: 'Patient',
+        };
+
+        const parsedFhirQueryParams: ParsedFhirQueryParams = {
+            resourceType: 'Practitioner',
+            searchParams: [],
+        };
+
+        expect(matchParsedFhirQueryParams(parsedFhirQueryParams, resource)).toBe(false);
+    });
+
+    test('simple case', () => {
+        const resource = {
+            resourceType: 'Patient',
+            name: {
+                given: 'Sherlock',
+                family: 'Holmes',
+            },
+        };
+
+        const parsedFhirQueryParams: ParsedFhirQueryParams = {
+            resourceType: 'Patient',
+            searchParams: [
+                { searchParam: givenParam, name: 'given', parsedSearchValues: ['Sherlock'], type: 'string' },
+            ],
+        };
+
+        expect(matchParsedFhirQueryParams(parsedFhirQueryParams, resource)).toBe(true);
+    });
+
+    test('simple case', () => {
+        const resource = {
+            resourceType: 'Patient',
+            name: [
+                {
+                    given: 'Sherlock',
+                    family: 'Holmes',
+                },
+            ],
+        };
+
+        const parsedFhirQueryParams: ParsedFhirQueryParams = {
+            resourceType: 'Patient',
+            searchParams: [
+                { searchParam: givenParam, name: 'given', parsedSearchValues: ['Sherlock'], type: 'string' },
+            ],
+        };
+
+        expect(matchParsedFhirQueryParams(parsedFhirQueryParams, resource)).toBe(true);
+    });
+
+    test('one of many fields match', () => {
+        const resource = {
+            resourceType: 'Patient',
+            name: [
+                {
+                    given: 'xxxx',
+                    family: 'xxxx',
+                },
+                {
+                    given: 'yyyy',
+                    family: 'yyyy',
+                },
+                {
+                    given: 'Sherlock',
+                    family: 'Holmes',
+                },
+            ],
+        };
+
+        const parsedFhirQueryParams: ParsedFhirQueryParams = {
+            resourceType: 'Patient',
+            searchParams: [
+                { searchParam: givenParam, name: 'given', parsedSearchValues: ['Sherlock'], type: 'string' },
+            ],
+        };
+
+        expect(matchParsedFhirQueryParams(parsedFhirQueryParams, resource)).toBe(true);
+    });
+
+    test('one of many search values match', () => {
+        const resource = {
+            resourceType: 'Patient',
+            name: [
+                {
+                    given: 'Sherlock',
+                    family: 'Holmes',
+                },
+            ],
+        };
+
+        const parsedFhirQueryParams: ParsedFhirQueryParams = {
+            resourceType: 'Patient',
+            searchParams: [
+                {
+                    searchParam: givenParam,
+                    name: 'given',
+                    parsedSearchValues: ['xxxx', 'yyyy', 'Sherlock'],
+                    type: 'string',
+                },
+            ],
+        };
+
+        expect(matchParsedFhirQueryParams(parsedFhirQueryParams, resource)).toBe(true);
+    });
+
+    test('one of many compiled search params matches', () => {
+        const resource = {
+            resourceType: 'Patient',
+            name: [
+                {
+                    given: 'Sherlock',
+                    family: 'Holmes',
+                },
+            ],
+        };
+
+        const modifiedGivenParam: SearchParam = {
+            ...givenParam,
+            compiled: [
+                { resourceType: 'Patient', path: 'some.path' },
+                { resourceType: 'Patient', path: 'resourceType' },
+                { resourceType: 'Patient', path: 'name.given' },
+            ],
+        };
+
+        const parsedFhirQueryParams: ParsedFhirQueryParams = {
+            resourceType: 'Patient',
+            searchParams: [
+                {
+                    searchParam: modifiedGivenParam,
+                    name: 'given',
+                    parsedSearchValues: ['Sherlock'],
+                    type: 'string',
+                },
+            ],
+        };
+
+        expect(matchParsedFhirQueryParams(parsedFhirQueryParams, resource)).toBe(true);
+    });
+
+    test('compiled conditions must pass', () => {
+        const modifiedGivenParam: SearchParam = {
+            ...givenParam,
+            compiled: [{ resourceType: 'Patient', path: 'name.given', condition: ['name.use', '=', 'official'] }],
+        };
+
+        const parsedFhirQueryParams: ParsedFhirQueryParams = {
+            resourceType: 'Patient',
+            searchParams: [
+                {
+                    searchParam: modifiedGivenParam,
+                    name: 'given',
+                    parsedSearchValues: ['Sherlock'],
+                    type: 'string',
+                },
+            ],
+        };
+
+        expect(
+            matchParsedFhirQueryParams(parsedFhirQueryParams, {
+                resourceType: 'Patient',
+                name: [
+                    {
+                        given: 'Sherlock',
+                        family: 'Holmes',
+                    },
+                ],
+            }),
+        ).toBe(false);
+
+        expect(
+            matchParsedFhirQueryParams(parsedFhirQueryParams, {
+                resourceType: 'Patient',
+                name: [
+                    {
+                        given: 'Sherlock',
+                        family: 'Holmes',
+                        use: 'official',
+                    },
+                ],
+            }),
+        ).toBe(true);
+    });
+
+    test('all searchParams must match', () => {
+        const parsedFhirQueryParams: ParsedFhirQueryParams = {
+            resourceType: 'Patient',
+            searchParams: [
+                {
+                    searchParam: givenParam,
+                    name: 'given',
+                    parsedSearchValues: ['Sherlock'],
+                    type: 'string',
+                },
+                {
+                    searchParam: familyParam,
+                    name: 'family',
+                    parsedSearchValues: ['Holmes'],
+                    type: 'string',
+                },
+            ],
+        };
+
+        expect(
+            matchParsedFhirQueryParams(parsedFhirQueryParams, {
+                resourceType: 'Patient',
+                name: [
+                    {
+                        given: 'Sherlock',
+                        family: 'Holmes',
+                    },
+                ],
+            }),
+        ).toBe(true);
+
+        expect(
+            matchParsedFhirQueryParams(parsedFhirQueryParams, {
+                resourceType: 'Patient',
+                name: [
+                    {
+                        given: 'Sherlock',
+                        family: 'H',
+                    },
+                ],
+            }),
+        ).toBe(false);
+    });
+});

--- a/src/InMemoryMatcher/index.ts
+++ b/src/InMemoryMatcher/index.ts
@@ -1,0 +1,103 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import {
+    DateSearchValue,
+    NumberSearchValue,
+    ParsedFhirQueryParams,
+    QueryParam,
+    StringLikeSearchValue,
+} from '../FhirQueryParser';
+import { CompiledSearchParam, SearchParam } from '../FHIRSearchParametersRegistry';
+import { numberMatch } from './matchers/numberMatch';
+import { dateMatch } from './matchers/dateMatch';
+import { getAllValuesForFHIRPath } from '../getAllValuesForFHIRPath';
+import { stringMatch } from './matchers/stringMatch';
+
+const typeMatcher = (
+    searchParam: SearchParam,
+    compiledSearchParam: CompiledSearchParam,
+    searchValue: unknown,
+    resourceValue: any,
+): boolean => {
+    switch (searchParam.type) {
+        case 'string':
+            return stringMatch(searchValue as StringLikeSearchValue, resourceValue);
+        case 'date':
+            return dateMatch(searchValue as DateSearchValue, resourceValue);
+        case 'number':
+            return numberMatch(searchValue as NumberSearchValue, resourceValue);
+        case 'quantity':
+            break;
+        case 'reference':
+            break;
+        case 'token':
+            break;
+        case 'composite':
+            break;
+        case 'special':
+            break;
+        case 'uri':
+            break;
+        default:
+            // eslint-disable-next-line no-case-declarations
+            const exhaustiveCheck: never = searchParam.type;
+            return exhaustiveCheck;
+    }
+
+    return false;
+};
+
+function evaluateCompiledCondition(condition: string[] | undefined, resource: any): boolean {
+    if (condition === undefined) {
+        return true;
+    }
+
+    const resourceValues = getAllValuesForFHIRPath(resource, condition[0]);
+
+    if (condition[1] === '=') {
+        return resourceValues.some((resourceValue) => resourceValue === condition[2]);
+    }
+
+    if (condition[1] === 'resolve') {
+        const resourceType = condition[2];
+        return resourceValues.some((resourceValue) => {
+            const referenceField = resourceValue?.reference;
+            return (
+                resourceValue?.type === resourceType ||
+                (typeof referenceField === 'string' && referenceField.startsWith(`${resourceType}/`))
+            );
+        });
+    }
+
+    return false;
+}
+
+function evaluateQueryParam(queryParam: QueryParam, resource: any): boolean {
+    return queryParam.parsedSearchValues.some((parsedSearchValue) =>
+        queryParam.searchParam.compiled.some(
+            (compiled) =>
+                evaluateCompiledCondition(compiled.condition, resource) &&
+                getAllValuesForFHIRPath(resource, compiled.path).some((resourceValue) =>
+                    typeMatcher(queryParam.searchParam, compiled, parsedSearchValue, resourceValue),
+                ),
+        ),
+    );
+}
+
+/**
+ * checks if the given resource is matched by a FHIR search query
+ * @param parsedFhirQueryParams - parsed FHIR search query
+ * @param resource - FHIR resource to be matched
+ */
+// eslint-disable-next-line import/prefer-default-export
+export function matchParsedFhirQueryParams(parsedFhirQueryParams: ParsedFhirQueryParams, resource: any): boolean {
+    if (parsedFhirQueryParams.resourceType !== resource?.resourceType) {
+        return false;
+    }
+
+    return parsedFhirQueryParams.searchParams.every((queryParam) => evaluateQueryParam(queryParam, resource));
+}

--- a/src/InMemoryMatcher/matchers/common/__snapshots__/numericComparison.test.ts.snap
+++ b/src/InMemoryMatcher/matchers/common/__snapshots__/numericComparison.test.ts.snap
@@ -1,0 +1,253 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`compareNumberToRange "ap" 1`] = `
+Array [
+  "(10) ap (8, 9) is false",
+  "(10) ap (9, 10) is true",
+  "(10) ap (9, 11) is true",
+  "(10) ap (10, 11) is true",
+  "(10) ap (11, 12) is false",
+]
+`;
+
+exports[`compareNumberToRange "eb" 1`] = `
+Array [
+  "(10) eb (8, 9) is false",
+  "(10) eb (9, 10) is false",
+  "(10) eb (9, 11) is false",
+  "(10) eb (10, 11) is false",
+  "(10) eb (11, 12) is true",
+]
+`;
+
+exports[`compareNumberToRange "eq" 1`] = `
+Array [
+  "(10) eq (8, 9) is false",
+  "(10) eq (9, 10) is true",
+  "(10) eq (9, 11) is true",
+  "(10) eq (10, 11) is true",
+  "(10) eq (11, 12) is false",
+]
+`;
+
+exports[`compareNumberToRange "ge" 1`] = `
+Array [
+  "(10) ge (8, 9) is true",
+  "(10) ge (9, 10) is true",
+  "(10) ge (9, 11) is true",
+  "(10) ge (10, 11) is true",
+  "(10) ge (11, 12) is false",
+]
+`;
+
+exports[`compareNumberToRange "gt" 1`] = `
+Array [
+  "(10) gt (8, 9) is true",
+  "(10) gt (9, 10) is true",
+  "(10) gt (9, 11) is true",
+  "(10) gt (10, 11) is false",
+  "(10) gt (11, 12) is false",
+]
+`;
+
+exports[`compareNumberToRange "le" 1`] = `
+Array [
+  "(10) le (8, 9) is false",
+  "(10) le (9, 10) is true",
+  "(10) le (9, 11) is true",
+  "(10) le (10, 11) is true",
+  "(10) le (11, 12) is true",
+]
+`;
+
+exports[`compareNumberToRange "lt" 1`] = `
+Array [
+  "(10) lt (8, 9) is false",
+  "(10) lt (9, 10) is false",
+  "(10) lt (9, 11) is true",
+  "(10) lt (10, 11) is true",
+  "(10) lt (11, 12) is true",
+]
+`;
+
+exports[`compareNumberToRange "ne" 1`] = `
+Array [
+  "(10) ne (8, 9) is true",
+  "(10) ne (9, 10) is false",
+  "(10) ne (9, 11) is false",
+  "(10) ne (10, 11) is false",
+  "(10) ne (11, 12) is true",
+]
+`;
+
+exports[`compareNumberToRange "sa" 1`] = `
+Array [
+  "(10) sa (8, 9) is true",
+  "(10) sa (9, 10) is false",
+  "(10) sa (9, 11) is false",
+  "(10) sa (10, 11) is false",
+  "(10) sa (11, 12) is false",
+]
+`;
+
+exports[`compareRanges "ap" 1`] = `
+Array [
+  "(10, 20) ap (8, 9) is false",
+  "(10, 20) ap (9, 10) is true",
+  "(10, 20) ap (9, 15) is true",
+  "(10, 20) ap (9, 20) is true",
+  "(10, 20) ap (9, 21) is true",
+  "(10, 20) ap (10, 15) is true",
+  "(10, 20) ap (10, 20) is true",
+  "(10, 20) ap (10, 21) is true",
+  "(10, 20) ap (11, 19) is true",
+  "(10, 20) ap (15, 20) is true",
+  "(10, 20) ap (15, 21) is true",
+  "(10, 20) ap (20, 21) is true",
+  "(10, 20) ap (21, 22) is false",
+]
+`;
+
+exports[`compareRanges "eb" 1`] = `
+Array [
+  "(10, 20) eb (8, 9) is false",
+  "(10, 20) eb (9, 10) is false",
+  "(10, 20) eb (9, 15) is false",
+  "(10, 20) eb (9, 20) is false",
+  "(10, 20) eb (9, 21) is false",
+  "(10, 20) eb (10, 15) is false",
+  "(10, 20) eb (10, 20) is false",
+  "(10, 20) eb (10, 21) is false",
+  "(10, 20) eb (11, 19) is false",
+  "(10, 20) eb (15, 20) is false",
+  "(10, 20) eb (15, 21) is false",
+  "(10, 20) eb (20, 21) is false",
+  "(10, 20) eb (21, 22) is true",
+]
+`;
+
+exports[`compareRanges "eq" 1`] = `
+Array [
+  "(10, 20) eq (8, 9) is false",
+  "(10, 20) eq (9, 10) is false",
+  "(10, 20) eq (9, 15) is false",
+  "(10, 20) eq (9, 20) is true",
+  "(10, 20) eq (9, 21) is true",
+  "(10, 20) eq (10, 15) is false",
+  "(10, 20) eq (10, 20) is true",
+  "(10, 20) eq (10, 21) is true",
+  "(10, 20) eq (11, 19) is false",
+  "(10, 20) eq (15, 20) is false",
+  "(10, 20) eq (15, 21) is false",
+  "(10, 20) eq (20, 21) is false",
+  "(10, 20) eq (21, 22) is false",
+]
+`;
+
+exports[`compareRanges "ge" 1`] = `
+Array [
+  "(10, 20) ge (8, 9) is true",
+  "(10, 20) ge (9, 10) is true",
+  "(10, 20) ge (9, 15) is true",
+  "(10, 20) ge (9, 20) is true",
+  "(10, 20) ge (9, 21) is true",
+  "(10, 20) ge (10, 15) is true",
+  "(10, 20) ge (10, 20) is true",
+  "(10, 20) ge (10, 21) is true",
+  "(10, 20) ge (11, 19) is true",
+  "(10, 20) ge (15, 20) is true",
+  "(10, 20) ge (15, 21) is true",
+  "(10, 20) ge (20, 21) is true",
+  "(10, 20) ge (21, 22) is false",
+]
+`;
+
+exports[`compareRanges "gt" 1`] = `
+Array [
+  "(10, 20) gt (8, 9) is true",
+  "(10, 20) gt (9, 10) is true",
+  "(10, 20) gt (9, 15) is true",
+  "(10, 20) gt (9, 20) is true",
+  "(10, 20) gt (9, 21) is true",
+  "(10, 20) gt (10, 15) is true",
+  "(10, 20) gt (10, 20) is true",
+  "(10, 20) gt (10, 21) is true",
+  "(10, 20) gt (11, 19) is true",
+  "(10, 20) gt (15, 20) is true",
+  "(10, 20) gt (15, 21) is true",
+  "(10, 20) gt (20, 21) is true",
+  "(10, 20) gt (21, 22) is false",
+]
+`;
+
+exports[`compareRanges "le" 1`] = `
+Array [
+  "(10, 20) le (8, 9) is false",
+  "(10, 20) le (9, 10) is true",
+  "(10, 20) le (9, 15) is true",
+  "(10, 20) le (9, 20) is true",
+  "(10, 20) le (9, 21) is true",
+  "(10, 20) le (10, 15) is true",
+  "(10, 20) le (10, 20) is true",
+  "(10, 20) le (10, 21) is true",
+  "(10, 20) le (11, 19) is true",
+  "(10, 20) le (15, 20) is true",
+  "(10, 20) le (15, 21) is true",
+  "(10, 20) le (20, 21) is true",
+  "(10, 20) le (21, 22) is true",
+]
+`;
+
+exports[`compareRanges "lt" 1`] = `
+Array [
+  "(10, 20) lt (8, 9) is false",
+  "(10, 20) lt (9, 10) is true",
+  "(10, 20) lt (9, 15) is true",
+  "(10, 20) lt (9, 20) is true",
+  "(10, 20) lt (9, 21) is true",
+  "(10, 20) lt (10, 15) is true",
+  "(10, 20) lt (10, 20) is true",
+  "(10, 20) lt (10, 21) is true",
+  "(10, 20) lt (11, 19) is true",
+  "(10, 20) lt (15, 20) is true",
+  "(10, 20) lt (15, 21) is true",
+  "(10, 20) lt (20, 21) is true",
+  "(10, 20) lt (21, 22) is true",
+]
+`;
+
+exports[`compareRanges "ne" 1`] = `
+Array [
+  "(10, 20) ne (8, 9) is true",
+  "(10, 20) ne (9, 10) is true",
+  "(10, 20) ne (9, 15) is true",
+  "(10, 20) ne (9, 20) is false",
+  "(10, 20) ne (9, 21) is false",
+  "(10, 20) ne (10, 15) is true",
+  "(10, 20) ne (10, 20) is false",
+  "(10, 20) ne (10, 21) is false",
+  "(10, 20) ne (11, 19) is true",
+  "(10, 20) ne (15, 20) is true",
+  "(10, 20) ne (15, 21) is true",
+  "(10, 20) ne (20, 21) is true",
+  "(10, 20) ne (21, 22) is true",
+]
+`;
+
+exports[`compareRanges "sa" 1`] = `
+Array [
+  "(10, 20) sa (8, 9) is true",
+  "(10, 20) sa (9, 10) is false",
+  "(10, 20) sa (9, 15) is false",
+  "(10, 20) sa (9, 20) is false",
+  "(10, 20) sa (9, 21) is false",
+  "(10, 20) sa (10, 15) is false",
+  "(10, 20) sa (10, 20) is false",
+  "(10, 20) sa (10, 21) is false",
+  "(10, 20) sa (11, 19) is false",
+  "(10, 20) sa (15, 20) is false",
+  "(10, 20) sa (15, 21) is false",
+  "(10, 20) sa (20, 21) is false",
+  "(10, 20) sa (21, 22) is false",
+]
+`;

--- a/src/InMemoryMatcher/matchers/common/numericComparison.test.ts
+++ b/src/InMemoryMatcher/matchers/common/numericComparison.test.ts
@@ -1,0 +1,72 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { compareNumberToRange, compareRanges } from './numericComparison';
+
+const prefixes = ['ne', 'eq', 'lt', 'le', 'gt', 'ge', 'sa', 'eb', 'ap'];
+
+describe('compareNumberToRange', () => {
+    const resourceValue = 10;
+    const ranges = [
+        [8, 9],
+        [9, 10],
+        [9, 11],
+        [10, 11],
+        [11, 12],
+    ];
+    test.each(prefixes)('%p', (prefix) => {
+        const results = ranges.map(
+            ([start, end]) =>
+                `(${resourceValue}) ${prefix} (${start}, ${end}) is ${compareNumberToRange(
+                    prefix,
+                    { start, end },
+                    resourceValue,
+                )}`,
+        );
+
+        expect(results).toMatchSnapshot();
+    });
+});
+
+describe('compareRanges', () => {
+    const resourceRange = {
+        lowerBound: 10,
+        upperBound: 20,
+    };
+
+    const ranges = [
+        [8, 9],
+        [9, 10],
+        [9, 15],
+        [9, 20],
+        [9, 21],
+        [10, 15],
+        [10, 20],
+        [10, 21],
+        [11, 19],
+        [15, 20],
+        [15, 21],
+        [20, 21],
+        [21, 22],
+    ];
+
+    console.log(ranges);
+
+    test.each(prefixes)('%p', (prefix) => {
+        const results = ranges.map(
+            ([start, end]) =>
+                `(${resourceRange.lowerBound}, ${
+                    resourceRange.upperBound
+                }) ${prefix} (${start}, ${end}) is ${compareRanges(
+                    prefix,
+                    { start, end },
+                    { start: resourceRange.lowerBound, end: resourceRange.upperBound },
+                )}`,
+        );
+
+        expect(results).toMatchSnapshot();
+    });
+});

--- a/src/InMemoryMatcher/matchers/common/numericComparison.ts
+++ b/src/InMemoryMatcher/matchers/common/numericComparison.ts
@@ -1,0 +1,68 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+export interface Range {
+    start: number;
+    end: number;
+}
+
+export const compareNumberToRange = (prefix: string, searchParamRange: Range, resourceValue: number): boolean => {
+    const { start, end } = searchParamRange;
+    // See https://www.hl7.org/fhir/search.html#prefix
+    switch (prefix) {
+        case 'ne': // not equal
+            return resourceValue < start || resourceValue > end;
+        case 'eq': // equal
+            return resourceValue >= start && resourceValue <= end;
+        case 'lt': // less than
+            return resourceValue < end;
+        case 'le': // less or equal
+            return resourceValue <= end;
+        case 'gt': // greater than
+            return resourceValue > start;
+        case 'ge': // greater or equal
+            return resourceValue >= start;
+        case 'sa': // starts after
+            return resourceValue > end;
+        case 'eb': // ends before
+            return resourceValue < start;
+        case 'ap': // approximately
+            // same as eq for now
+            return resourceValue >= start && resourceValue <= end;
+        default:
+            // this should never happen
+            throw new Error(`unknown search prefix: ${prefix}`);
+    }
+};
+
+// See the interpretation of prefixes when applied to ranges: https://www.hl7.org/fhir/search.html#prefix. It can be counterintuitive at first
+export const compareRanges = (prefix: string, searchParamRange: Range, resourceRange: Range): any => {
+    const { start, end } = searchParamRange;
+    const resourceStart = resourceRange.start;
+    const resourceEnd = resourceRange.end;
+    // See https://www.hl7.org/fhir/search.html#prefix
+    switch (prefix) {
+        case 'ne': // not equal
+            return !(resourceStart >= start && resourceEnd <= end);
+        case 'eq': // equal
+            return resourceStart >= start && resourceEnd <= end;
+        case 'lt': // less than
+        case 'le': // less or equal
+            return resourceStart <= end;
+        case 'gt': // greater than
+        case 'ge': // greater or equal
+            return resourceEnd >= start;
+        case 'sa': // starts after
+            return resourceStart > end;
+        case 'eb': // ends before
+            return resourceEnd < start;
+        case 'ap': // approximately
+            return !(resourceStart > end) && !(resourceEnd < start);
+        default:
+            // this should never happen
+            throw new Error(`unknown search prefix: ${prefix}`);
+    }
+};

--- a/src/InMemoryMatcher/matchers/dateMatch.ts
+++ b/src/InMemoryMatcher/matchers/dateMatch.ts
@@ -1,0 +1,42 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import isValid from 'date-fns/isValid';
+import parseISO from 'date-fns/parseISO';
+import { DateSearchValue } from '../../FhirQueryParser';
+
+import { compareNumberToRange, compareRanges } from './common/numericComparison';
+
+// eslint-disable-next-line import/prefer-default-export
+export const dateMatch = (searchValue: DateSearchValue, resourceValue: any): boolean => {
+    const { prefix, range } = searchValue;
+    const numericSearchRange = { start: range.start.getTime(), end: range.end.getTime() };
+
+    if (typeof resourceValue === 'string') {
+        const parsedDate = parseISO(resourceValue);
+        if (!isValid(parsedDate)) {
+            return false;
+        }
+
+        return compareNumberToRange(prefix, numericSearchRange, parsedDate.getTime());
+    }
+
+    if (typeof resourceValue?.start === 'string' && typeof resourceValue?.end === 'string') {
+        const startDate = parseISO(resourceValue.start);
+        if (!isValid(startDate)) {
+            return false;
+        }
+
+        const endDate = parseISO(resourceValue.end);
+        if (!isValid(endDate)) {
+            return false;
+        }
+
+        return compareRanges(prefix, numericSearchRange, { start: startDate.getTime(), end: endDate.getTime() });
+    }
+
+    return false;
+};

--- a/src/InMemoryMatcher/matchers/numberMatch.test.ts
+++ b/src/InMemoryMatcher/matchers/numberMatch.test.ts
@@ -1,0 +1,135 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { numberMatch } from './numberMatch';
+
+describe('numberMatch', () => {
+    describe('eq', () => {
+        const numberSearchValue = {
+            prefix: 'eq',
+            number: 100,
+            implicitRange: { start: 99.5, end: 100.5 },
+        };
+        test.each([
+            [99.5, true],
+            [100, true],
+            [100.5, true],
+            [99.4, false],
+            [101, false],
+        ])('%p eq 100 is %p', async (number, expected) => {
+            expect(numberMatch(numberSearchValue, number)).toBe(expected);
+        });
+    });
+
+    describe('ne', () => {
+        const numberSearchValue = {
+            prefix: 'ne',
+            number: 100,
+            implicitRange: { start: 99.5, end: 100.5 },
+        };
+        test.each([
+            [99.5, false],
+            [100, false],
+            [100.5, false],
+            [99.4, true],
+            [101, true],
+        ])('%p ne 100 is %p', async (number, expected) => {
+            expect(numberMatch(numberSearchValue, number)).toBe(expected);
+        });
+    });
+
+    describe('lt', () => {
+        const numberSearchValue = {
+            prefix: 'lt',
+            number: 100,
+            implicitRange: { start: 99.5, end: 100.5 },
+        };
+        test.each([
+            [90, true],
+            [99.9, true],
+            [110, false],
+            [100, false],
+        ])('%p lt 100 is %p', async (number, expected) => {
+            expect(numberMatch(numberSearchValue, number)).toBe(expected);
+        });
+    });
+
+    describe('le', () => {
+        const numberSearchValue = {
+            prefix: 'le',
+            number: 100,
+            implicitRange: { start: 99.5, end: 100.5 },
+        };
+        test.each([
+            [100, true],
+            [99.9, true],
+            [110, false],
+        ])('%p le 100 is %p', async (number, expected) => {
+            expect(numberMatch(numberSearchValue, number)).toBe(expected);
+        });
+    });
+
+    describe('gt', () => {
+        const numberSearchValue = {
+            prefix: 'gt',
+            number: 100,
+            implicitRange: { start: 99.5, end: 100.5 },
+        };
+        test.each([
+            [100, false],
+            [99.9, false],
+            [110, true],
+        ])('%p gt 100 is %p', async (number, expected) => {
+            expect(numberMatch(numberSearchValue, number)).toBe(expected);
+        });
+    });
+
+    describe('ge', () => {
+        const numberSearchValue = {
+            prefix: 'ge',
+            number: 100,
+            implicitRange: { start: 99.5, end: 100.5 },
+        };
+        test.each([
+            [100, true],
+            [110, true],
+            [99.9, false],
+        ])('%p ge 100 is %p', async (number, expected) => {
+            expect(numberMatch(numberSearchValue, number)).toBe(expected);
+        });
+    });
+
+    describe('eb', () => {
+        const numberSearchValue = {
+            prefix: 'eb',
+            number: 100,
+            implicitRange: { start: 99.5, end: 100.5 },
+        };
+        test.each([
+            [90, true],
+            [99.9, true],
+            [110, false],
+            [100, false],
+        ])('%p eb 100 is %p', async (number, expected) => {
+            expect(numberMatch(numberSearchValue, number)).toBe(expected);
+        });
+    });
+
+    describe('sa', () => {
+        const numberSearchValue = {
+            prefix: 'sa',
+            number: 100,
+            implicitRange: { start: 99.5, end: 100.5 },
+        };
+        test.each([
+            [100, false],
+            [99.9, false],
+            [110, true],
+        ])('%p sa 100 is %p', async (number, expected) => {
+            expect(numberMatch(numberSearchValue, number)).toBe(expected);
+        });
+    });
+});

--- a/src/InMemoryMatcher/matchers/numberMatch.ts
+++ b/src/InMemoryMatcher/matchers/numberMatch.ts
@@ -1,0 +1,33 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { NumberSearchValue } from '../../FhirQueryParser';
+import { compareNumberToRange } from './common/numericComparison';
+
+// eslint-disable-next-line import/prefer-default-export
+export const numberMatch = (value: NumberSearchValue, resourceValue: any): boolean => {
+    const { prefix, implicitRange, number } = value;
+
+    if (typeof resourceValue !== 'number') {
+        return false;
+    }
+
+    if (prefix === 'eq' || prefix === 'ne') {
+        return compareNumberToRange(prefix, implicitRange, resourceValue);
+    }
+
+    // When a comparison prefix in the set lgt, lt, ge, le, sa & eb is provided, the implicit precision of the number is ignored,
+    // and they are treated as if they have arbitrarily high precision
+    // https://www.hl7.org/fhir/search.html#number
+    return compareNumberToRange(
+        prefix,
+        {
+            start: number,
+            end: number,
+        },
+        resourceValue,
+    );
+};

--- a/src/InMemoryMatcher/matchers/stringMatch.test.ts
+++ b/src/InMemoryMatcher/matchers/stringMatch.test.ts
@@ -1,0 +1,20 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { stringMatch } from './stringMatch';
+
+describe('stringMatch', () => {
+    test('matches string', () => {
+        expect(stringMatch('hello', 'hello')).toBe(true);
+        expect(stringMatch('hello', 'something else')).toBe(false);
+    });
+
+    test('not a string', () => {
+        expect(stringMatch('hello', [])).toBe(false);
+        expect(stringMatch('hello', {})).toBe(false);
+        expect(stringMatch('hello', 23.1)).toBe(false);
+    });
+});

--- a/src/InMemoryMatcher/matchers/stringMatch.ts
+++ b/src/InMemoryMatcher/matchers/stringMatch.ts
@@ -1,0 +1,15 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { StringLikeSearchValue } from '../../FhirQueryParser';
+
+// eslint-disable-next-line import/prefer-default-export
+export const stringMatch = (value: StringLikeSearchValue, resourceValue: any): boolean => {
+    if (typeof resourceValue === 'string') {
+        return value === resourceValue;
+    }
+    return false;
+};


### PR DESCRIPTION
Add the `InMemoryMatcher` that will be used to match FHIR resources against the Subscription.criteria search queries.
In general `InMemoryMatcher` shares many similarities with the `QueryBuilder`.

Right now this handles the `date` and `number` types. Support for more types will be added in separate PRs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.