### PR TITLE
feat: add quantity matcher

### DIFF
--- a/src/InMemoryMatcher/index.ts
+++ b/src/InMemoryMatcher/index.ts
@@ -8,6 +8,7 @@ import {
     DateSearchValue,
     NumberSearchValue,
     ParsedFhirQueryParams,
+    QuantitySearchValue,
     QueryParam,
     StringLikeSearchValue,
 } from '../FhirQueryParser';
@@ -16,6 +17,7 @@ import { numberMatch } from './matchers/numberMatch';
 import { dateMatch } from './matchers/dateMatch';
 import { getAllValuesForFHIRPath } from '../getAllValuesForFHIRPath';
 import { stringMatch } from './matchers/stringMatch';
+import { quantityMatch } from './matchers/quantityMatch';
 
 const typeMatcher = (
     searchParam: SearchParam,
@@ -31,7 +33,7 @@ const typeMatcher = (
         case 'number':
             return numberMatch(searchValue as NumberSearchValue, resourceValue);
         case 'quantity':
-            break;
+            return quantityMatch(searchValue as QuantitySearchValue, resourceValue);
         case 'reference':
             break;
         case 'token':

--- a/src/InMemoryMatcher/matchers/common/numericComparison.ts
+++ b/src/InMemoryMatcher/matchers/common/numericComparison.ts
@@ -66,3 +66,18 @@ export const compareRanges = (prefix: string, searchParamRange: Range, resourceR
             throw new Error(`unknown search prefix: ${prefix}`);
     }
 };
+
+/**
+ * When a comparison prefix in the set lgt, lt, ge, le, sa & eb is provided, the implicit precision of the number is ignored,
+ * and they are treated as if they have arbitrarily high precision. https://www.hl7.org/fhir/search.html#number
+ * @param prefix
+ * @param number
+ * @param range
+ */
+export const applyPrefixRulesToRange = (prefix: string, number: number, range: Range): Range => {
+    if (prefix === 'eq' || prefix === 'ne') {
+        return range;
+    }
+
+    return { start: number, end: number };
+};

--- a/src/InMemoryMatcher/matchers/numberMatch.ts
+++ b/src/InMemoryMatcher/matchers/numberMatch.ts
@@ -5,7 +5,7 @@
  */
 
 import { NumberSearchValue } from '../../FhirQueryParser';
-import { compareNumberToRange } from './common/numericComparison';
+import { applyPrefixRulesToRange, compareNumberToRange } from './common/numericComparison';
 
 // eslint-disable-next-line import/prefer-default-export
 export const numberMatch = (value: NumberSearchValue, resourceValue: any): boolean => {
@@ -15,19 +15,5 @@ export const numberMatch = (value: NumberSearchValue, resourceValue: any): boole
         return false;
     }
 
-    if (prefix === 'eq' || prefix === 'ne') {
-        return compareNumberToRange(prefix, implicitRange, resourceValue);
-    }
-
-    // When a comparison prefix in the set lgt, lt, ge, le, sa & eb is provided, the implicit precision of the number is ignored,
-    // and they are treated as if they have arbitrarily high precision
-    // https://www.hl7.org/fhir/search.html#number
-    return compareNumberToRange(
-        prefix,
-        {
-            start: number,
-            end: number,
-        },
-        resourceValue,
-    );
+    return compareNumberToRange(prefix, applyPrefixRulesToRange(prefix, number, implicitRange), resourceValue);
 };

--- a/src/InMemoryMatcher/matchers/quantityMatch.test.ts
+++ b/src/InMemoryMatcher/matchers/quantityMatch.test.ts
@@ -1,0 +1,112 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { QuantitySearchValue } from '../../FhirQueryParser';
+import { quantityMatch } from './quantityMatch';
+
+describe('quantityMatch', () => {
+    test('only number', () => {
+        const quantitySearchValue: QuantitySearchValue = {
+            prefix: 'eq',
+            system: '',
+            code: '',
+            number: 10,
+            implicitRange: { start: 9.5, end: 10.5 },
+        };
+
+        expect(
+            quantityMatch(quantitySearchValue, {
+                value: 10,
+                system: 'SYSTEM',
+                code: 'CODE',
+                unit: 'U',
+            }),
+        ).toBe(true);
+
+        expect(
+            quantityMatch(quantitySearchValue, {
+                value: 999,
+                system: 'SYSTEM',
+                code: 'CODE',
+                unit: 'U',
+            }),
+        ).toBe(false);
+    });
+
+    test('system and code', () => {
+        const quantitySearchValue: QuantitySearchValue = {
+            prefix: 'eq',
+            system: 'SYSTEM',
+            code: 'CODE',
+            number: 10,
+            implicitRange: { start: 9.5, end: 10.5 },
+        };
+
+        expect(
+            quantityMatch(quantitySearchValue, {
+                value: 10,
+                system: 'SYSTEM',
+                code: 'CODE',
+                unit: 'U',
+            }),
+        ).toBe(true);
+
+        expect(
+            quantityMatch(quantitySearchValue, {
+                value: 10,
+                system: 'xxxx',
+                code: 'CODE',
+                unit: 'U',
+            }),
+        ).toBe(false);
+
+        expect(
+            quantityMatch(quantitySearchValue, {
+                value: 10,
+                system: 'SYSTEM',
+                code: 'xxxx',
+                unit: 'U',
+            }),
+        ).toBe(false);
+    });
+
+    test('only code', () => {
+        const quantitySearchValue: QuantitySearchValue = {
+            prefix: 'eq',
+            system: '',
+            code: 'CODE',
+            number: 10,
+            implicitRange: { start: 9.5, end: 10.5 },
+        };
+
+        expect(
+            quantityMatch(quantitySearchValue, {
+                value: 10,
+                system: 'xxxx',
+                code: 'CODE',
+                unit: 'U',
+            }),
+        ).toBe(true);
+
+        expect(
+            quantityMatch(quantitySearchValue, {
+                value: 10,
+                system: 'xxxx',
+                code: 'xxxx',
+                unit: 'CODE',
+            }),
+        ).toBe(true);
+
+        expect(
+            quantityMatch(quantitySearchValue, {
+                value: 10,
+                system: 'xxxx',
+                code: 'xxxx',
+                unit: 'xxxx',
+            }),
+        ).toBe(false);
+    });
+});

--- a/src/InMemoryMatcher/matchers/quantityMatch.ts
+++ b/src/InMemoryMatcher/matchers/quantityMatch.ts
@@ -1,0 +1,31 @@
+import { isEmpty } from 'lodash';
+import { QuantitySearchValue } from '../../FhirQueryParser';
+import { applyPrefixRulesToRange, compareNumberToRange } from './common/numericComparison';
+
+// eslint-disable-next-line import/prefer-default-export
+export const quantityMatch = (value: QuantitySearchValue, resourceValue: any): boolean => {
+    const { prefix, implicitRange, number, system, code } = value;
+
+    if (typeof resourceValue?.value !== 'number') {
+        return false;
+    }
+
+    if (!compareNumberToRange(prefix, applyPrefixRulesToRange(prefix, number, implicitRange), resourceValue.value)) {
+        return false;
+    }
+
+    if (isEmpty(system) && isEmpty(code)) {
+        return true;
+    }
+
+    if (!isEmpty(system) && !isEmpty(code)) {
+        return resourceValue?.code === code && resourceValue?.system === system;
+    }
+    if (!isEmpty(code)) {
+        // when there is no system, search either the code (code) or the stated human unit (unit)
+        // https://www.hl7.org/fhir/search.html#quantity
+        return resourceValue?.code === code || resourceValue?.unit === code;
+    }
+
+    return false;
+};


### PR DESCRIPTION
Adds the quantity matcher to the InMemoryMatcher

This PR is on top of https://github.com/awslabs/fhir-works-on-aws-search-es/pull/156

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.