### PR TITLE
feat: add extension.valueReference in mapping

### DIFF
--- a/src/elasticSearchService.ts
+++ b/src/elasticSearchService.ts
@@ -321,9 +321,8 @@ export class ElasticSearchService implements Search {
                 index: getAliasName(searchQuery.resourceType, request.tenantId),
                 ...(request.sessionId && { preference: request.sessionId }),
             };
-            if (logger.isDebugEnabled()) {
-                logger.debug(`Elastic search query: ${JSON.stringify(searchQueryWithAlias, null, 2)}`);
-            }
+            console.error(`Elastic search query: ${JSON.stringify(searchQueryWithAlias, null, 2)}`);
+
             const apiResponse = await this.esClient.search(searchQueryWithAlias);
             return {
                 total: apiResponse.body.hits.total.value,

--- a/src/elasticSearchService.ts
+++ b/src/elasticSearchService.ts
@@ -321,8 +321,9 @@ export class ElasticSearchService implements Search {
                 index: getAliasName(searchQuery.resourceType, request.tenantId),
                 ...(request.sessionId && { preference: request.sessionId }),
             };
-            console.error(`Elastic search query: ${JSON.stringify(searchQueryWithAlias, null, 2)}`);
-
+            if (logger.isDebugEnabled()) {
+                logger.debug(`Elastic search query: ${JSON.stringify(searchQueryWithAlias, null, 2)}`);
+            }
             const apiResponse = await this.esClient.search(searchQueryWithAlias);
             return {
                 total: apiResponse.body.hits.total.value,

--- a/src/schema/searchMappingsBase.4.0.1.json
+++ b/src/schema/searchMappingsBase.4.0.1.json
@@ -57,6 +57,10 @@
       "type": "Coding"
     },
     {
+      "field": "extension.valueReference",
+      "type": "Reference"
+    },
+    {
       "field": "extension.valueCodeableConcept",
       "type": "CodeableConcept"
     },


### PR DESCRIPTION
When we want to search FHIR resources by extension.valueReference, we get empty list.  This PR would add mapping for extension.valueReference in order to search by valueReference.

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.