### PR TITLE
feat: add string, token, uri matchers

### DIFF
--- a/src/InMemoryMatcher/index.ts
+++ b/src/InMemoryMatcher/index.ts
@@ -27,7 +27,7 @@ const typeMatcher = (
 ): boolean => {
     switch (searchParam.type) {
         case 'string':
-            return stringMatch(searchValue as StringLikeSearchValue, resourceValue);
+            return stringMatch(compiledSearchParam, searchValue as StringLikeSearchValue, resourceValue);
         case 'date':
             return dateMatch(searchValue as DateSearchValue, resourceValue);
         case 'number':

--- a/src/InMemoryMatcher/matchers/stringMatch.test.ts
+++ b/src/InMemoryMatcher/matchers/stringMatch.test.ts
@@ -5,16 +5,43 @@
  */
 
 import { stringMatch } from './stringMatch';
+import { CompiledSearchParam } from '../../FHIRSearchParametersRegistry';
+
+const COMPILED_SEARCH_PARAM: CompiledSearchParam = { path: 'someField', resourceType: 'someResource' };
 
 describe('stringMatch', () => {
     test('matches string', () => {
-        expect(stringMatch('hello', 'hello')).toBe(true);
-        expect(stringMatch('hello', 'something else')).toBe(false);
+        expect(stringMatch(COMPILED_SEARCH_PARAM, 'hello', 'hello')).toBe(true);
+        expect(stringMatch(COMPILED_SEARCH_PARAM, 'hello', 'something else')).toBe(false);
     });
 
     test('not a string', () => {
-        expect(stringMatch('hello', [])).toBe(false);
-        expect(stringMatch('hello', {})).toBe(false);
-        expect(stringMatch('hello', 23.1)).toBe(false);
+        expect(stringMatch(COMPILED_SEARCH_PARAM, 'hello', [])).toBe(false);
+        expect(stringMatch(COMPILED_SEARCH_PARAM, 'hello', {})).toBe(false);
+        expect(stringMatch(COMPILED_SEARCH_PARAM, 'hello', 23.1)).toBe(false);
+    });
+
+    describe('special cases', () => {
+        describe('name', () => {
+            test.each(['family', 'given', 'text', 'prefix', 'suffix'])('%p field', (field) => {
+                const compiledNameParam = { path: 'name', resourceType: 'someResource' };
+                expect(
+                    stringMatch(compiledNameParam, 'John', {
+                        [field]: 'John',
+                    }),
+                ).toBe(true);
+            });
+        });
+
+        describe('address', () => {
+            test.each(['city', 'country', 'district', 'line', 'postalCode', 'state', 'text'])('%p field', (field) => {
+                const compiledNameParam = { path: 'address', resourceType: 'someResource' };
+                expect(
+                    stringMatch(compiledNameParam, 'somePlace', {
+                        [field]: 'somePlace',
+                    }),
+                ).toBe(true);
+            });
+        });
     });
 });

--- a/src/InMemoryMatcher/matchers/stringMatch.ts
+++ b/src/InMemoryMatcher/matchers/stringMatch.ts
@@ -5,11 +5,41 @@
  */
 
 import { StringLikeSearchValue } from '../../FhirQueryParser';
+import { CompiledSearchParam } from '../../FHIRSearchParametersRegistry';
 
 // eslint-disable-next-line import/prefer-default-export
-export const stringMatch = (value: StringLikeSearchValue, resourceValue: any): boolean => {
-    if (typeof resourceValue === 'string') {
-        return value === resourceValue;
+export const stringMatch = (
+    compiledSearchParam: CompiledSearchParam,
+    value: StringLikeSearchValue,
+    resourceValue: any,
+): boolean => {
+    if (compiledSearchParam.path === 'name') {
+        // name is a special parameter.
+        const nameFields = [
+            resourceValue?.family,
+            resourceValue?.given,
+            resourceValue?.text,
+            resourceValue?.prefix,
+            resourceValue?.suffix,
+        ];
+
+        return nameFields.some((f) => f === value);
     }
-    return false;
+
+    if (compiledSearchParam.path === 'address') {
+        // address is a special parameter.
+        const addressFields = [
+            resourceValue?.city,
+            resourceValue?.country,
+            resourceValue?.district,
+            resourceValue?.line,
+            resourceValue?.postalCode,
+            resourceValue?.state,
+            resourceValue?.text,
+        ];
+
+        return addressFields.some((f) => f === value);
+    }
+
+    return value === resourceValue;
 };

--- a/src/InMemoryMatcher/matchers/tokenMatch.test.ts
+++ b/src/InMemoryMatcher/matchers/tokenMatch.test.ts
@@ -1,0 +1,160 @@
+import { TokenSearchValue } from '../../FhirQueryParser';
+import { tokenMatch } from './tokenMatch';
+
+describe('tokenMatch', () => {
+    test('system and code', () => {
+        const tokenParam: TokenSearchValue = {
+            code: 'code',
+            explicitNoSystemProperty: false,
+            system: 'system',
+        };
+
+        expect(
+            tokenMatch(tokenParam, {
+                code: 'code',
+                system: 'system',
+            }),
+        ).toBe(true);
+
+        expect(
+            tokenMatch(tokenParam, {
+                value: 'code',
+                system: 'system',
+            }),
+        ).toBe(true);
+
+        expect(
+            tokenMatch(tokenParam, {
+                coding: [
+                    {
+                        system: 'xxxx',
+                        code: 'xxxx',
+                    },
+                    {
+                        system: 'system',
+                        code: 'code',
+                    },
+                ],
+            }),
+        ).toBe(true);
+
+        expect(
+            tokenMatch(tokenParam, {
+                code: 'code',
+                system: 'xxxx',
+            }),
+        ).toBe(false);
+
+        expect(
+            tokenMatch(tokenParam, {
+                code: 'xxxx',
+                system: 'system',
+            }),
+        ).toBe(false);
+    });
+
+    describe('only code', () => {
+        test('explicitNoSystemProperty is true', () => {
+            const tokenParam = {
+                code: 'code',
+                explicitNoSystemProperty: true,
+                system: undefined,
+            };
+
+            expect(
+                tokenMatch(tokenParam, {
+                    code: 'code',
+                }),
+            ).toBe(true);
+
+            expect(
+                tokenMatch(tokenParam, {
+                    code: 'code',
+                    system: 'system',
+                }),
+            ).toBe(false);
+        });
+
+        describe('explicitNoSystemProperty is false', () => {
+            test('coding-like type', () => {
+                const tokenParam = {
+                    code: 'code',
+                    explicitNoSystemProperty: false,
+                    system: undefined,
+                };
+
+                expect(
+                    tokenMatch(tokenParam, {
+                        code: 'code',
+                        system: 'system',
+                    }),
+                ).toBe(true);
+
+                expect(
+                    tokenMatch(tokenParam, {
+                        code: 'code',
+                    }),
+                ).toBe(true);
+
+                expect(tokenMatch(tokenParam, 'code')).toBe(true);
+
+                expect(
+                    tokenMatch(tokenParam, {
+                        code: 'xxxx',
+                    }),
+                ).toBe(false);
+            });
+
+            test('boolean type', () => {
+                expect(
+                    tokenMatch(
+                        {
+                            code: 'true',
+                            explicitNoSystemProperty: false,
+                            system: undefined,
+                        },
+                        true,
+                    ),
+                ).toBe(true);
+
+                expect(
+                    tokenMatch(
+                        {
+                            code: 'false',
+                            explicitNoSystemProperty: false,
+                            system: undefined,
+                        },
+                        false,
+                    ),
+                ).toBe(true);
+            });
+        });
+    });
+
+    describe('only system', () => {
+        const tokenParam = {
+            code: undefined,
+            explicitNoSystemProperty: false,
+            system: 'system',
+        };
+
+        expect(
+            tokenMatch(tokenParam, {
+                code: 'xxxx',
+                system: 'system',
+            }),
+        ).toBe(true);
+
+        expect(
+            tokenMatch(tokenParam, {
+                system: 'system',
+            }),
+        ).toBe(true);
+
+        expect(
+            tokenMatch(tokenParam, {
+                system: 'xxxx',
+            }),
+        ).toBe(false);
+    });
+});

--- a/src/InMemoryMatcher/matchers/tokenMatch.ts
+++ b/src/InMemoryMatcher/matchers/tokenMatch.ts
@@ -1,0 +1,50 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { TokenSearchValue } from '../../FhirQueryParser';
+
+// eslint-disable-next-line import/prefer-default-export
+export const tokenMatch = (searchValue: TokenSearchValue, resourceValue: any): boolean => {
+    const { system, code, explicitNoSystemProperty } = searchValue;
+
+    // CodeableConcept may have several Codings
+    if (resourceValue?.coding) {
+        if (Array.isArray(resourceValue?.coding)) {
+            return resourceValue?.coding.some((coding: any) => tokenMatch(searchValue, coding));
+        }
+        return tokenMatch(searchValue, resourceValue?.coding);
+    }
+
+    const codeValues = [
+        resourceValue?.code, // Coding
+        resourceValue?.value, // Identifier, ContactPoint
+        resourceValue, // code, uri, string, boolean
+    ];
+
+    const systemValue = resourceValue?.system;
+
+    if (explicitNoSystemProperty && systemValue !== undefined) {
+        return false;
+    }
+
+    if (system !== undefined && systemValue !== system) {
+        return false;
+    }
+
+    if (
+        code !== undefined &&
+        codeValues.every((codeValue) => {
+            if (typeof codeValue === 'boolean') {
+                return (code === 'true' && !codeValue) || (code === 'false' && codeValue);
+            }
+            return codeValue !== code;
+        })
+    ) {
+        return false;
+    }
+
+    return true;
+};

--- a/src/InMemoryMatcher/matchers/uriMatch.test.ts
+++ b/src/InMemoryMatcher/matchers/uriMatch.test.ts
@@ -1,0 +1,14 @@
+import { uriMatch } from './uriMatch';
+
+describe('uriMatch', () => {
+    test('matches string', () => {
+        expect(uriMatch('https://fwoa.com', 'https://fwoa.com')).toBe(true);
+        expect(uriMatch('https://fwoa.com', 'something else')).toBe(false);
+    });
+
+    test('not a string', () => {
+        expect(uriMatch('https://fwoa.com', [])).toBe(false);
+        expect(uriMatch('https://fwoa.com', {})).toBe(false);
+        expect(uriMatch('https://fwoa.com', 23.1)).toBe(false);
+    });
+});

--- a/src/InMemoryMatcher/matchers/uriMatch.ts
+++ b/src/InMemoryMatcher/matchers/uriMatch.ts
@@ -1,0 +1,12 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { StringLikeSearchValue } from '../../FhirQueryParser';
+
+// eslint-disable-next-line import/prefer-default-export
+export const uriMatch = (searchValue: StringLikeSearchValue, resourceValue: any): boolean => {
+    return searchValue === resourceValue;
+};


### PR DESCRIPTION
Adds the token and uri matchers to the InMemoryMatcher. Also, finishes the string matcher implementation (it previously was a trivial string comparison since at least one matcher implementation was needed to facilitate unit testing the `InMemoryMatcher`)

This PR is on top of https://github.com/awslabs/fhir-works-on-aws-search-es/pull/156

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.