### PR TITLE
refactor: add referenceParser

### DIFF
--- a/src/FhirQueryParser/index.ts
+++ b/src/FhirQueryParser/index.ts
@@ -15,6 +15,7 @@ import { DateSearchValue, parseDateSearchValue } from './typeParsers/dateParser'
 import { parseTokenSearchValue, TokenSearchValue } from './typeParsers/tokenParser';
 import { NumberSearchValue, parseNumberSearchValue } from './typeParsers/numberParser';
 import { parseQuantitySearchValue, QuantitySearchValue } from './typeParsers/quantityParser';
+import { parseReferenceSearchValue, ReferenceSearchValue } from './typeParsers/referenceParser';
 
 export { DateSearchValue, TokenSearchValue, NumberSearchValue, QuantitySearchValue };
 
@@ -63,7 +64,7 @@ export interface QuantityQueryParam extends BaseQueryParam {
 
 export interface ReferenceQueryParam extends BaseQueryParam {
     type: 'reference';
-    parsedSearchValues: StringLikeSearchValue[];
+    parsedSearchValues: ReferenceSearchValue[];
 }
 
 export interface TokenQueryParam extends BaseQueryParam {
@@ -121,7 +122,9 @@ const parseSearchQueryParam = (searchParam: SearchParam, rawSearchValue: string)
                 type: searchParam.type,
                 name: searchParam.name,
                 searchParam,
-                parsedSearchValues: orSearchValues.map(parseStringLikeSearchValue),
+                parsedSearchValues: orSearchValues.map((searchValue) =>
+                    parseReferenceSearchValue(searchParam, searchValue),
+                ),
             };
         case 'string':
             return {

--- a/src/FhirQueryParser/typeParsers/referenceParser.test.ts
+++ b/src/FhirQueryParser/typeParsers/referenceParser.test.ts
@@ -1,0 +1,68 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { InvalidSearchParameterError } from 'fhir-works-on-aws-interface';
+import { parseReferenceSearchValue } from './referenceParser';
+
+const referenceParam = {
+    name: 'ref',
+    base: 'Patient',
+    target: ['Organization'],
+};
+
+describe('parseReferenceSearchValue', () => {
+    describe('searching with {type}/{id}', () => {
+        test('valid param', () => {
+            expect(parseReferenceSearchValue(referenceParam, 'Organization/111')).toMatchInlineSnapshot(`
+                Object {
+                  "id": "111",
+                  "resourceType": "Organization",
+                }
+            `);
+        });
+    });
+    describe('searching with {fhirServiceBaseUrl}/{type}/{id}', () => {
+        test('valid param', () => {
+            expect(parseReferenceSearchValue(referenceParam, 'https://base-url.com/Organization/111'))
+                .toMatchInlineSnapshot(`
+                Object {
+                  "fhirServiceBaseUrl": "https://base-url.com",
+                  "id": "111",
+                  "resourceType": "Organization",
+                }
+            `);
+        });
+    });
+    describe('searching with just {id}', () => {
+        test('one target type found', () => {
+            expect(parseReferenceSearchValue(referenceParam, 'organizationId')).toMatchInlineSnapshot(`
+                Object {
+                  "id": "organizationId",
+                }
+            `);
+        });
+        test('many target types found', () => {
+            expect(parseReferenceSearchValue({ ...referenceParam, target: ['A', 'B'] }, 'organizationId'))
+                .toMatchInlineSnapshot(`
+                Object {
+                  "id": "organizationId",
+                }
+            `);
+        });
+        test('no target types found', () => {
+            expect(() => parseReferenceSearchValue({ ...referenceParam, target: [] }, 'organizationId')).toThrow(
+                InvalidSearchParameterError,
+            );
+            expect(() => parseReferenceSearchValue({ ...referenceParam, target: undefined }, 'organizationId')).toThrow(
+                InvalidSearchParameterError,
+            );
+        });
+    });
+    test('search value is not an URL nor has the format <resourceType>/<id>', () => {
+        expect(() => parseReferenceSearchValue(referenceParam, 'this:does# not match')).toThrow(
+            InvalidSearchParameterError,
+        );
+    });
+});

--- a/src/FhirQueryParser/typeParsers/referenceParser.test.ts
+++ b/src/FhirQueryParser/typeParsers/referenceParser.test.ts
@@ -18,6 +18,7 @@ describe('parseReferenceSearchValue', () => {
             expect(parseReferenceSearchValue(referenceParam, 'Organization/111')).toMatchInlineSnapshot(`
                 Object {
                   "id": "111",
+                  "referenceType": "relative",
                   "resourceType": "Organization",
                 }
             `);
@@ -30,6 +31,7 @@ describe('parseReferenceSearchValue', () => {
                 Object {
                   "fhirServiceBaseUrl": "https://base-url.com",
                   "id": "111",
+                  "referenceType": "url",
                   "resourceType": "Organization",
                 }
             `);
@@ -40,6 +42,7 @@ describe('parseReferenceSearchValue', () => {
             expect(parseReferenceSearchValue(referenceParam, 'organizationId')).toMatchInlineSnapshot(`
                 Object {
                   "id": "organizationId",
+                  "referenceType": "idOnly",
                 }
             `);
         });
@@ -48,6 +51,7 @@ describe('parseReferenceSearchValue', () => {
                 .toMatchInlineSnapshot(`
                 Object {
                   "id": "organizationId",
+                  "referenceType": "idOnly",
                 }
             `);
         });
@@ -61,8 +65,11 @@ describe('parseReferenceSearchValue', () => {
         });
     });
     test('search value is not an URL nor has the format <resourceType>/<id>', () => {
-        expect(() => parseReferenceSearchValue(referenceParam, 'this:does# not match')).toThrow(
-            InvalidSearchParameterError,
-        );
+        expect(parseReferenceSearchValue(referenceParam, 'this:does# not match')).toMatchInlineSnapshot(`
+            Object {
+              "rawValue": "this:does# not match",
+              "referenceType": "unparseable",
+            }
+        `);
     });
 });

--- a/src/FhirQueryParser/typeParsers/referenceParser.ts
+++ b/src/FhirQueryParser/typeParsers/referenceParser.ts
@@ -1,0 +1,79 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { InvalidSearchParameterError } from 'fhir-works-on-aws-interface';
+import getComponentLogger from '../../loggerBuilder';
+
+export interface ReferenceSearchValueIdOnly {
+    referenceType: 'idOnly';
+    id: string;
+    inferredType: string;
+}
+
+export interface ReferenceSearchValueRelative {
+    referenceType: 'relative';
+    id: string;
+    type: string;
+}
+
+export interface ReferenceSearchValueUrl {
+    referenceType: 'url';
+    fullUrl: string;
+    id: string;
+    type: string;
+}
+
+// export type ReferenceSearchValue = ReferenceSearchValueIdOnly | ReferenceSearchValueRelative | ReferenceSearchValueUrl;
+export interface ReferenceSearchValue {
+    id: string;
+    resourceType?: string;
+    fhirServiceBaseUrl?: string;
+}
+
+const logger = getComponentLogger();
+const ID_ONLY_REGEX = /^[A-Za-z0-9\-.]{1,64}$/;
+const FHIR_REFERENCE_REGEX =
+    /^((?<fhirServiceBaseUrl>https?:\/\/[A-Za-z0-9\-\\.:%$_/]+)\/)?(?<resourceType>[A-Z][a-zA-Z]+)\/(?<id>[A-Za-z0-9\-.]{1,64})$/;
+
+export const parseReferenceSearchValue = (
+    { target, name }: { target?: string[]; name: string },
+    param: string,
+): ReferenceSearchValue => {
+    const match = param.match(FHIR_REFERENCE_REGEX);
+    if (match) {
+        const { fhirServiceBaseUrl, resourceType, id } = match.groups!;
+        if (fhirServiceBaseUrl) {
+            return {
+                id,
+                resourceType,
+                fhirServiceBaseUrl,
+            };
+        }
+        if (!fhirServiceBaseUrl) {
+            return {
+                id,
+                resourceType,
+            };
+        }
+    }
+
+    if (ID_ONLY_REGEX.test(param)) {
+        if (target === undefined || target.length === 0) {
+            logger.error(
+                `ID only reference search failed. The requested search parameter: '${name}',  does not have any targets. Please ensure the compiled IG is valid`,
+            );
+            throw new InvalidSearchParameterError(
+                `ID only search for '${name}' parameter is not supported, please specify the value with the format [resourceType]/[id] or as an absolute URL`,
+            );
+        }
+
+        return {
+            id: param,
+        };
+    }
+
+    throw new InvalidSearchParameterError(`Invalid reference search parameter: ${param}`);
+};

--- a/src/FhirQueryParser/typeParsers/referenceParser.ts
+++ b/src/FhirQueryParser/typeParsers/referenceParser.ts
@@ -7,25 +7,6 @@
 import { InvalidSearchParameterError } from 'fhir-works-on-aws-interface';
 import getComponentLogger from '../../loggerBuilder';
 
-export interface ReferenceSearchValueIdOnly {
-    referenceType: 'idOnly';
-    id: string;
-    inferredType: string;
-}
-
-export interface ReferenceSearchValueRelative {
-    referenceType: 'relative';
-    id: string;
-    type: string;
-}
-
-export interface ReferenceSearchValueUrl {
-    referenceType: 'url';
-    fullUrl: string;
-    id: string;
-    type: string;
-}
-
 // export type ReferenceSearchValue = ReferenceSearchValueIdOnly | ReferenceSearchValueRelative | ReferenceSearchValueUrl;
 export interface ReferenceSearchValue {
     id: string;

--- a/src/FhirQueryParser/typeParsers/referenceParser.ts
+++ b/src/FhirQueryParser/typeParsers/referenceParser.ts
@@ -56,15 +56,12 @@ export const parseReferenceSearchValue = (
                 fhirServiceBaseUrl,
             };
         }
-        if (!fhirServiceBaseUrl) {
-            return {
-                referenceType: 'relative',
-                id,
-                resourceType,
-            };
-        }
+        return {
+            referenceType: 'relative',
+            id,
+            resourceType,
+        };
     }
-
     if (ID_ONLY_REGEX.test(param)) {
         if (target === undefined || target.length === 0) {
             logger.error(

--- a/src/QueryBuilder/index.ts
+++ b/src/QueryBuilder/index.ts
@@ -21,6 +21,7 @@ import {
     QuantitySearchValue,
     TokenSearchValue,
 } from '../FhirQueryParser';
+import { ReferenceSearchValue } from '../FhirQueryParser/typeParsers/referenceParser';
 
 function typeQueryWithConditions(
     searchParam: SearchParam,
@@ -55,7 +56,7 @@ function typeQueryWithConditions(
         case 'reference':
             typeQuery = referenceQuery(
                 compiledSearchParam,
-                searchValue as string,
+                searchValue as ReferenceSearchValue,
                 useKeywordSubFields,
                 baseUrl,
                 searchParam.name,

--- a/src/QueryBuilder/typeQueries/referenceQuery.test.ts
+++ b/src/QueryBuilder/typeQueries/referenceQuery.test.ts
@@ -175,4 +175,25 @@ describe('referenceQuery', () => {
             ),
         ).toThrow(InvalidSearchParameterError);
     });
+
+    test('search value is not an URL nor has the format <resourceType>/<id>', () => {
+        expect(
+            referenceQuery(
+                organizationParam,
+                parseReferenceSearchValue({ name: 'organization', target: [] }, 'this:does# not match'),
+                true,
+                'https://base-url.com',
+                'organization',
+                ['Organization', 'Group'],
+            ),
+        ).toMatchInlineSnapshot(`
+          Object {
+            "terms": Object {
+              "managingOrganization.reference.keyword": Array [
+                "this:does# not match",
+              ],
+            },
+          }
+        `);
+    });
 });

--- a/src/QueryBuilder/typeQueries/referenceQuery.test.ts
+++ b/src/QueryBuilder/typeQueries/referenceQuery.test.ts
@@ -6,6 +6,7 @@
 import { InvalidSearchParameterError } from 'fhir-works-on-aws-interface';
 import { referenceQuery } from './referenceQuery';
 import { FHIRSearchParametersRegistry } from '../../FHIRSearchParametersRegistry';
+import { parseReferenceSearchValue } from '../../FhirQueryParser/typeParsers/referenceParser';
 
 const fhirSearchParametersRegistry = new FHIRSearchParametersRegistry('4.0.1');
 const organizationParam = fhirSearchParametersRegistry.getSearchParameter('Patient', 'organization')!.compiled[0];
@@ -14,30 +15,44 @@ describe('referenceQuery', () => {
     describe('searching with {type}/{id}', () => {
         test('keyword included', () => {
             expect(
-                referenceQuery(organizationParam, 'Organization/111', true, 'https://base-url.com', 'organization', []),
+                referenceQuery(
+                    organizationParam,
+                    parseReferenceSearchValue({ name: 'organization', target: [] }, 'Organization/111'),
+                    true,
+                    'https://base-url.com',
+                    'organization',
+                    [],
+                ),
             ).toMatchInlineSnapshot(`
-              Object {
-                "terms": Object {
-                  "managingOrganization.reference.keyword": Array [
-                    "Organization/111",
-                    "https://base-url.com/Organization/111",
-                  ],
-                },
-              }
-            `);
+                              Object {
+                                "terms": Object {
+                                  "managingOrganization.reference.keyword": Array [
+                                    "Organization/111",
+                                    "https://base-url.com/Organization/111",
+                                  ],
+                                },
+                              }
+                        `);
         });
         test('keyword not included', () => {
-            expect(referenceQuery(organizationParam, 'Organization/111', false, 'https://base-url.com', 'organization'))
-                .toMatchInlineSnapshot(`
-              Object {
-                "terms": Object {
-                  "managingOrganization.reference": Array [
-                    "Organization/111",
-                    "https://base-url.com/Organization/111",
-                  ],
-                },
-              }
-            `);
+            expect(
+                referenceQuery(
+                    organizationParam,
+                    parseReferenceSearchValue({ name: 'organization', target: [] }, 'Organization/111'),
+                    false,
+                    'https://base-url.com',
+                    'organization',
+                ),
+            ).toMatchInlineSnapshot(`
+                              Object {
+                                "terms": Object {
+                                  "managingOrganization.reference": Array [
+                                    "Organization/111",
+                                    "https://base-url.com/Organization/111",
+                                  ],
+                                },
+                              }
+                        `);
         });
     });
     describe('searching with {fhirServiceBaseUrl}/{type}/{id}', () => {
@@ -45,81 +60,105 @@ describe('referenceQuery', () => {
             expect(
                 referenceQuery(
                     organizationParam,
-                    'https://base-url.com/Organization/111',
+                    parseReferenceSearchValue(
+                        { name: 'organization', target: [] },
+                        'https://base-url.com/Organization/111',
+                    ),
                     true,
                     'https://base-url.com',
                     'organization',
                 ),
             ).toMatchInlineSnapshot(`
-              Object {
-                "terms": Object {
-                  "managingOrganization.reference.keyword": Array [
-                    "https://base-url.com/Organization/111",
-                    "Organization/111",
-                  ],
-                },
-              }
+                Object {
+                  "terms": Object {
+                    "managingOrganization.reference.keyword": Array [
+                      "Organization/111",
+                      "https://base-url.com/Organization/111",
+                    ],
+                  },
+                }
             `);
         });
         test('fhirServiceBaseUrl does not match baseUrl', () => {
             expect(
                 referenceQuery(
                     organizationParam,
-                    'http://notMatching.com/baseR4/Organization/111',
+                    parseReferenceSearchValue(
+                        { name: 'organization', target: [] },
+                        'http://notMatching.com/baseR4/Organization/111',
+                    ),
                     true,
                     'https://base-url.com',
                     'organization',
                 ),
             ).toMatchInlineSnapshot(`
-              Object {
-                "terms": Object {
-                  "managingOrganization.reference.keyword": Array [
-                    "http://notMatching.com/baseR4/Organization/111",
-                  ],
-                },
-              }
-            `);
+                              Object {
+                                "terms": Object {
+                                  "managingOrganization.reference.keyword": Array [
+                                    "http://notMatching.com/baseR4/Organization/111",
+                                  ],
+                                },
+                              }
+                        `);
         });
     });
     describe('searching with just {id}', () => {
         test('one target type found', () => {
             expect(
-                referenceQuery(organizationParam, 'organizationId', true, 'https://base-url.com', 'organization', [
-                    'Organization',
-                ]),
+                referenceQuery(
+                    organizationParam,
+                    parseReferenceSearchValue({ name: 'organization', target: ['Organization'] }, 'organizationId'),
+                    true,
+                    'https://base-url.com',
+                    'organization',
+                    ['Organization'],
+                ),
             ).toMatchInlineSnapshot(`
-              Object {
-                "terms": Object {
-                  "managingOrganization.reference.keyword": Array [
-                    "https://base-url.com/Organization/organizationId",
-                    "Organization/organizationId",
-                  ],
-                },
-              }
-            `);
+                              Object {
+                                "terms": Object {
+                                  "managingOrganization.reference.keyword": Array [
+                                    "https://base-url.com/Organization/organizationId",
+                                    "Organization/organizationId",
+                                  ],
+                                },
+                              }
+                        `);
         });
         test('many target types found', () => {
             expect(
-                referenceQuery(organizationParam, 'organizationId', true, 'https://base-url.com', 'organization', [
-                    'Organization',
-                    'Group',
-                ]),
+                referenceQuery(
+                    organizationParam,
+                    parseReferenceSearchValue(
+                        { name: 'organization', target: ['Organization', 'Group'] },
+                        'organizationId',
+                    ),
+                    true,
+                    'https://base-url.com',
+                    'organization',
+                    ['Organization', 'Group'],
+                ),
             ).toMatchInlineSnapshot(`
-              Object {
-                "terms": Object {
-                  "managingOrganization.reference.keyword": Array [
-                    "https://base-url.com/Organization/organizationId",
-                    "Organization/organizationId",
-                    "https://base-url.com/Group/organizationId",
-                    "Group/organizationId",
-                  ],
-                },
-              }
-            `);
+                              Object {
+                                "terms": Object {
+                                  "managingOrganization.reference.keyword": Array [
+                                    "https://base-url.com/Organization/organizationId",
+                                    "Organization/organizationId",
+                                    "https://base-url.com/Group/organizationId",
+                                    "Group/organizationId",
+                                  ],
+                                },
+                              }
+                        `);
         });
         test('no target types found', () => {
             expect(() =>
-                referenceQuery(organizationParam, 'organizationId', false, 'https://base-url.com', 'organization'),
+                referenceQuery(
+                    organizationParam,
+                    parseReferenceSearchValue({ name: 'organization', target: [] }, 'organizationId'),
+                    false,
+                    'https://base-url.com',
+                    'organization',
+                ),
             ).toThrow(InvalidSearchParameterError);
         });
     });
@@ -127,7 +166,7 @@ describe('referenceQuery', () => {
         expect(() =>
             referenceQuery(
                 organizationParam,
-                'organizationId',
+                parseReferenceSearchValue({ name: 'organization', target: ['Organization'] }, 'organizationId'),
                 false,
                 'https://base-url.com',
                 'organization',
@@ -135,21 +174,5 @@ describe('referenceQuery', () => {
                 'exact',
             ),
         ).toThrow(InvalidSearchParameterError);
-    });
-    test('search value is not an URL nor has the format <resourceType>/<id>', () => {
-        expect(
-            referenceQuery(organizationParam, 'this:does# not match', true, 'https://base-url.com', 'organization', [
-                'Organization',
-                'Group',
-            ]),
-        ).toMatchInlineSnapshot(`
-          Object {
-            "terms": Object {
-              "managingOrganization.reference.keyword": Array [
-                "this:does# not match",
-              ],
-            },
-          }
-        `);
     });
 });


### PR DESCRIPTION
Extracted the reference parsing logic into `referenceParser.ts`. There are no functional changes.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.