### PR TITLE
feat: add referenceMatcher

### DIFF
--- a/src/InMemoryMatcher/matchers/referenceMatcher.test.ts
+++ b/src/InMemoryMatcher/matchers/referenceMatcher.test.ts
@@ -1,0 +1,110 @@
+import { referenceMatch } from './referenceMatcher';
+import { ReferenceSearchValue } from '../../FhirQueryParser/typeParsers/referenceParser';
+
+describe('referenceMatch', () => {
+    describe('relative', () => {
+        test('relative reference in resource', () => {
+            const searchValue: ReferenceSearchValue = { id: '111', referenceType: 'relative', resourceType: 'Patient' };
+            const resourceValue = { reference: 'Patient/111' };
+            expect(
+                referenceMatch(searchValue, resourceValue, {
+                    baseUrl: 'xxxx',
+                    target: [],
+                }),
+            ).toBe(true);
+        });
+
+        test('matching full url in resource', () => {
+            const searchValue: ReferenceSearchValue = { id: '111', referenceType: 'relative', resourceType: 'Patient' };
+            const resourceValue = { reference: 'https://fwoa.com/Patient/111' };
+            expect(
+                referenceMatch(searchValue, resourceValue, {
+                    baseUrl: 'https://fwoa.com',
+                    target: [],
+                }),
+            ).toBe(true);
+        });
+
+        test('no match', () => {
+            const searchValue: ReferenceSearchValue = { id: '111', referenceType: 'relative', resourceType: 'Patient' };
+            const resourceValue = { reference: 'Patient/222' };
+            expect(
+                referenceMatch(searchValue, resourceValue, {
+                    baseUrl: '',
+                    target: [],
+                }),
+            ).toBe(false);
+        });
+    });
+
+    describe('url', () => {
+        test('relative reference in resource with matching baseUrl', () => {
+            const searchValue: ReferenceSearchValue = {
+                fhirServiceBaseUrl: 'https://fwoa.com',
+                id: '111',
+                referenceType: 'url',
+                resourceType: 'Patient',
+            };
+            const resourceValue = { reference: 'Patient/111' };
+            expect(
+                referenceMatch(searchValue, resourceValue, {
+                    baseUrl: 'https://fwoa.com',
+                    target: [],
+                }),
+            ).toBe(true);
+        });
+
+        test('matching full url in resource', () => {
+            const searchValue: ReferenceSearchValue = {
+                fhirServiceBaseUrl: 'https://fwoa.com',
+                id: '111',
+                referenceType: 'url',
+                resourceType: 'Patient',
+            };
+            const resourceValue = { reference: 'https://fwoa.com/Patient/111' };
+            expect(
+                referenceMatch(searchValue, resourceValue, {
+                    baseUrl: 'xxxx',
+                    target: [],
+                }),
+            ).toBe(true);
+        });
+    });
+
+    describe('idOnly', () => {
+        test('relative reference in resource', () => {
+            const searchValue: ReferenceSearchValue = { id: '111', referenceType: 'idOnly' };
+            const resourceValue = { reference: 'Patient/111' };
+            expect(
+                referenceMatch(searchValue, resourceValue, {
+                    baseUrl: 'xxxx',
+                    target: ['Patient'],
+                }),
+            ).toBe(true);
+        });
+
+        test('matching full url in resource', () => {
+            const searchValue: ReferenceSearchValue = { id: '111', referenceType: 'idOnly' };
+            const resourceValue = { reference: 'https://fwoa.com/Patient/111' };
+            expect(
+                referenceMatch(searchValue, resourceValue, {
+                    baseUrl: 'https://fwoa.com',
+                    target: ['Patient'],
+                }),
+            ).toBe(true);
+        });
+    });
+
+    describe('unparseable', () => {
+        test('matching raw search value', () => {
+            const searchValue: ReferenceSearchValue = { rawValue: '@#$_someValue_$#@', referenceType: 'unparseable' };
+            const resourceValue = { reference: '@#$_someValue_$#@' };
+            expect(
+                referenceMatch(searchValue, resourceValue, {
+                    baseUrl: 'xxxx',
+                    target: [],
+                }),
+            ).toBe(true);
+        });
+    });
+});

--- a/src/InMemoryMatcher/matchers/referenceMatcher.test.ts
+++ b/src/InMemoryMatcher/matchers/referenceMatcher.test.ts
@@ -8,7 +8,7 @@ describe('referenceMatch', () => {
             const resourceValue = { reference: 'Patient/111' };
             expect(
                 referenceMatch(searchValue, resourceValue, {
-                    baseUrl: 'xxxx',
+                    fhirServiceBaseUrl: 'xxxx',
                     target: [],
                 }),
             ).toBe(true);
@@ -19,7 +19,7 @@ describe('referenceMatch', () => {
             const resourceValue = { reference: 'https://fwoa.com/Patient/111' };
             expect(
                 referenceMatch(searchValue, resourceValue, {
-                    baseUrl: 'https://fwoa.com',
+                    fhirServiceBaseUrl: 'https://fwoa.com',
                     target: [],
                 }),
             ).toBe(true);
@@ -30,7 +30,7 @@ describe('referenceMatch', () => {
             const resourceValue = { reference: 'Patient/222' };
             expect(
                 referenceMatch(searchValue, resourceValue, {
-                    baseUrl: '',
+                    fhirServiceBaseUrl: '',
                     target: [],
                 }),
             ).toBe(false);
@@ -38,7 +38,7 @@ describe('referenceMatch', () => {
     });
 
     describe('url', () => {
-        test('relative reference in resource with matching baseUrl', () => {
+        test('relative reference in resource with matching base url', () => {
             const searchValue: ReferenceSearchValue = {
                 fhirServiceBaseUrl: 'https://fwoa.com',
                 id: '111',
@@ -48,7 +48,7 @@ describe('referenceMatch', () => {
             const resourceValue = { reference: 'Patient/111' };
             expect(
                 referenceMatch(searchValue, resourceValue, {
-                    baseUrl: 'https://fwoa.com',
+                    fhirServiceBaseUrl: 'https://fwoa.com',
                     target: [],
                 }),
             ).toBe(true);
@@ -64,7 +64,7 @@ describe('referenceMatch', () => {
             const resourceValue = { reference: 'https://fwoa.com/Patient/111' };
             expect(
                 referenceMatch(searchValue, resourceValue, {
-                    baseUrl: 'xxxx',
+                    fhirServiceBaseUrl: 'xxxx',
                     target: [],
                 }),
             ).toBe(true);
@@ -77,7 +77,7 @@ describe('referenceMatch', () => {
             const resourceValue = { reference: 'Patient/111' };
             expect(
                 referenceMatch(searchValue, resourceValue, {
-                    baseUrl: 'xxxx',
+                    fhirServiceBaseUrl: 'xxxx',
                     target: ['Patient'],
                 }),
             ).toBe(true);
@@ -88,8 +88,8 @@ describe('referenceMatch', () => {
             const resourceValue = { reference: 'https://fwoa.com/Patient/111' };
             expect(
                 referenceMatch(searchValue, resourceValue, {
-                    baseUrl: 'https://fwoa.com',
-                    target: ['Patient'],
+                    fhirServiceBaseUrl: 'https://fwoa.com',
+                    target: ['Observation', 'Practitioner', 'Patient'],
                 }),
             ).toBe(true);
         });
@@ -101,7 +101,7 @@ describe('referenceMatch', () => {
             const resourceValue = { reference: '@#$_someValue_$#@' };
             expect(
                 referenceMatch(searchValue, resourceValue, {
-                    baseUrl: 'xxxx',
+                    fhirServiceBaseUrl: 'xxxx',
                     target: [],
                 }),
             ).toBe(true);

--- a/src/InMemoryMatcher/matchers/referenceMatcher.ts
+++ b/src/InMemoryMatcher/matchers/referenceMatcher.ts
@@ -6,11 +6,18 @@
 
 import { ReferenceSearchValue } from '../../FhirQueryParser/typeParsers/referenceParser';
 
+/**
+ * @param searchValue - parsed search value
+ * @param resourceValue - value from the FHIR resource
+ * @param options.fhirServiceBaseUrl - URL of the FHIR served where the FHIR resource is located.
+ * The URL is used to translate relative references into full URLs and vice versa
+ * @param options.target - target resource types of the search parameter being evaluated.
+ */
 // eslint-disable-next-line import/prefer-default-export
 export const referenceMatch = (
     searchValue: ReferenceSearchValue,
     resourceValue: any,
-    { baseUrl, target = [] }: { baseUrl?: string; target?: string[] },
+    { fhirServiceBaseUrl, target = [] }: { fhirServiceBaseUrl?: string; target?: string[] },
 ): boolean => {
     const reference = resourceValue?.reference;
 
@@ -18,19 +25,21 @@ export const referenceMatch = (
         case 'idOnly':
             return target.some(
                 (targetType) =>
-                    (baseUrl !== undefined && `${baseUrl}/${targetType}/${searchValue.id}` === reference) ||
+                    (fhirServiceBaseUrl !== undefined &&
+                        `${fhirServiceBaseUrl}/${targetType}/${searchValue.id}` === reference) ||
                     `${targetType}/${searchValue.id}` === reference,
             );
         case 'relative':
             return (
-                (baseUrl !== undefined && `${baseUrl}/${searchValue.resourceType}/${searchValue.id}` === reference) ||
+                (fhirServiceBaseUrl !== undefined &&
+                    `${fhirServiceBaseUrl}/${searchValue.resourceType}/${searchValue.id}` === reference) ||
                 `${searchValue.resourceType}/${searchValue.id}` === reference
             );
         case 'url':
             return (
                 `${searchValue.fhirServiceBaseUrl}/${searchValue.resourceType}/${searchValue.id}` === reference ||
-                (baseUrl !== undefined &&
-                    searchValue.fhirServiceBaseUrl === baseUrl &&
+                (fhirServiceBaseUrl !== undefined &&
+                    searchValue.fhirServiceBaseUrl === fhirServiceBaseUrl &&
                     `${searchValue.resourceType}/${searchValue.id}` === reference)
             );
         case 'unparseable':

--- a/src/InMemoryMatcher/matchers/referenceMatcher.ts
+++ b/src/InMemoryMatcher/matchers/referenceMatcher.ts
@@ -1,0 +1,43 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { ReferenceSearchValue } from '../../FhirQueryParser/typeParsers/referenceParser';
+
+// eslint-disable-next-line import/prefer-default-export
+export const referenceMatch = (
+    searchValue: ReferenceSearchValue,
+    resourceValue: any,
+    { baseUrl, target = [] }: { baseUrl?: string; target?: string[] },
+): boolean => {
+    const reference = resourceValue?.reference;
+
+    switch (searchValue.referenceType) {
+        case 'idOnly':
+            return target.some(
+                (targetType) =>
+                    (baseUrl !== undefined && `${baseUrl}/${targetType}/${searchValue.id}` === reference) ||
+                    `${targetType}/${searchValue.id}` === reference,
+            );
+        case 'relative':
+            return (
+                (baseUrl !== undefined && `${baseUrl}/${searchValue.resourceType}/${searchValue.id}` === reference) ||
+                `${searchValue.resourceType}/${searchValue.id}` === reference
+            );
+        case 'url':
+            return (
+                `${searchValue.fhirServiceBaseUrl}/${searchValue.resourceType}/${searchValue.id}` === reference ||
+                (baseUrl !== undefined &&
+                    searchValue.fhirServiceBaseUrl === baseUrl &&
+                    `${searchValue.resourceType}/${searchValue.id}` === reference)
+            );
+        case 'unparseable':
+            return reference === searchValue.rawValue;
+        default:
+            // eslint-disable-next-line no-case-declarations
+            const exhaustiveCheck: never = searchValue;
+            return exhaustiveCheck;
+    }
+};


### PR DESCRIPTION
Adds the referebce matcher to the InMemoryMatcher

This PR builds on top on recent changes to the referenceParser:https://github.com/awslabs/fhir-works-on-aws-search-es/pull/160

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.