### PR TITLE
feat: support modifiers in InMemoryMatcher

### DIFF
--- a/src/FhirQueryParser/index.test.ts
+++ b/src/FhirQueryParser/index.test.ts
@@ -42,6 +42,12 @@ describe('queryParser', () => {
         `);
     });
 
+    test('string with unknown modifier', () => {
+        expect(() =>
+            parseQuery(fhirSearchParametersRegistry, 'Patient', { 'name:unknownModifier': 'John' }),
+        ).toThrowErrorMatchingInlineSnapshot(`"Unsupported string search modifier: unknownModifier"`);
+    });
+
     test('string OR', () => {
         const q = parseQuery(fhirSearchParametersRegistry, 'Patient', { 'name:exact': 'John,Anna' });
         expect(q).toMatchInlineSnapshot(`

--- a/src/FhirQueryParser/index.ts
+++ b/src/FhirQueryParser/index.ts
@@ -169,6 +169,14 @@ const parseSearchQueryParam = (searchParam: SearchParam, rawSearchValue: string)
     }
 };
 
+const validateModifiers = ({ type, modifier }: QueryParam): void => {
+    // There are other valid modifiers in the FHIR spec, but this validation only accepts the modifiers currently implemented in FWoA
+    const SUPPORTED_MODIFIERS: string[] = ['exact', 'contains'];
+    if (type === 'string' && modifier !== undefined && !SUPPORTED_MODIFIERS.includes(modifier)) {
+        throw new InvalidSearchParameterError(`Unsupported string search modifier: ${modifier}`);
+    }
+};
+
 /**
  * Parse and validate the search query parameters. This method ignores _include, _revinclude, _sort, and chained parameters
  * @param fhirSearchParametersRegistry - instance of FHIRSearchParametersRegistry
@@ -229,6 +237,7 @@ export const parseQuery = (
         return searchValues.map((searchValue) => {
             const parsedQueryParam = parseSearchQueryParam(fhirSearchParam, searchValue);
             parsedQueryParam.modifier = searchModifier.modifier;
+            validateModifiers(parsedQueryParam);
             return parsedQueryParam;
         });
     });

--- a/src/InMemoryMatcher/index.ts
+++ b/src/InMemoryMatcher/index.ts
@@ -22,15 +22,17 @@ import { referenceMatch } from './matchers/referenceMatcher';
 import { ReferenceSearchValue } from '../FhirQueryParser/typeParsers/referenceParser';
 
 const typeMatcher = (
-    searchParam: SearchParam,
+    queryParam: QueryParam,
     compiledSearchParam: CompiledSearchParam,
     searchValue: unknown,
     resourceValue: any,
     { fhirServiceBaseUrl }: { fhirServiceBaseUrl?: string } = {},
 ): boolean => {
+    const { searchParam, modifier } = queryParam;
+
     switch (searchParam.type) {
         case 'string':
-            return stringMatch(compiledSearchParam, searchValue as StringLikeSearchValue, resourceValue);
+            return stringMatch(compiledSearchParam, searchValue as StringLikeSearchValue, resourceValue, modifier);
         case 'date':
             return dateMatch(searchValue as DateSearchValue, resourceValue);
         case 'number':
@@ -94,7 +96,7 @@ function evaluateQueryParam(
             (compiled) =>
                 evaluateCompiledCondition(compiled.condition, resource) &&
                 getAllValuesForFHIRPath(resource, compiled.path).some((resourceValue) =>
-                    typeMatcher(queryParam.searchParam, compiled, parsedSearchValue, resourceValue, {
+                    typeMatcher(queryParam, compiled, parsedSearchValue, resourceValue, {
                         fhirServiceBaseUrl,
                     }),
                 ),

--- a/src/InMemoryMatcher/matchers/stringMatch.test.ts
+++ b/src/InMemoryMatcher/matchers/stringMatch.test.ts
@@ -12,7 +12,25 @@ const COMPILED_SEARCH_PARAM: CompiledSearchParam = { path: 'someField', resource
 describe('stringMatch', () => {
     test('matches string', () => {
         expect(stringMatch(COMPILED_SEARCH_PARAM, 'hello', 'hello')).toBe(true);
+        expect(stringMatch(COMPILED_SEARCH_PARAM, 'hello', 'hello world')).toBe(true);
+        expect(stringMatch(COMPILED_SEARCH_PARAM, 'hello', 'hello-world')).toBe(true);
         expect(stringMatch(COMPILED_SEARCH_PARAM, 'hello', 'something else')).toBe(false);
+    });
+
+    test('modifier :exact', () => {
+        expect(stringMatch(COMPILED_SEARCH_PARAM, 'hello', 'hello', 'exact')).toBe(true);
+        expect(stringMatch(COMPILED_SEARCH_PARAM, 'hello', 'hello world', 'exact')).toBe(false);
+    });
+
+    test('modifier :contains', () => {
+        expect(stringMatch(COMPILED_SEARCH_PARAM, 'hello', 'XXXXXhelloXXXX', 'contains')).toBe(true);
+        expect(stringMatch(COMPILED_SEARCH_PARAM, 'hello', 'something else', 'contains')).toBe(false);
+    });
+
+    test('unsupported modifier', () => {
+        expect(() =>
+            stringMatch(COMPILED_SEARCH_PARAM, 'hello', 'hello', 'unknownModifier'),
+        ).toThrowErrorMatchingInlineSnapshot(`"The modifier \\":unknownModifier\\" is not supported"`);
     });
 
     test('not a string', () => {

--- a/src/InMemoryMatcher/matchers/stringMatch.ts
+++ b/src/InMemoryMatcher/matchers/stringMatch.ts
@@ -7,39 +7,72 @@
 import { StringLikeSearchValue } from '../../FhirQueryParser';
 import { CompiledSearchParam } from '../../FHIRSearchParametersRegistry';
 
+const comparisons = {
+    eq: (a: unknown, b: string) => typeof a === 'string' && a.split(/[ \-,.]/).includes(b), // simple approximation of the way OpenSearch matches text fields.
+    exact: (a: unknown, b: string) => a === b,
+    contains: (a: unknown, b: string) => typeof a === 'string' && a.includes(b),
+};
+
+function isUsableType(x: unknown): x is string | Record<string, unknown> {
+    return x !== null && (typeof x === 'string' || typeof x === 'object');
+}
+
 // eslint-disable-next-line import/prefer-default-export
 export const stringMatch = (
     compiledSearchParam: CompiledSearchParam,
     value: StringLikeSearchValue,
-    resourceValue: any,
+    resourceValue: unknown,
+    modifier?: string,
 ): boolean => {
-    if (compiledSearchParam.path === 'name') {
-        // name is a special parameter.
-        const nameFields = [
-            resourceValue?.family,
-            resourceValue?.given,
-            resourceValue?.text,
-            resourceValue?.prefix,
-            resourceValue?.suffix,
-        ];
-
-        return nameFields.some((f) => f === value);
+    if (!isUsableType(resourceValue)) {
+        return false;
     }
 
-    if (compiledSearchParam.path === 'address') {
-        // address is a special parameter.
-        const addressFields = [
-            resourceValue?.city,
-            resourceValue?.country,
-            resourceValue?.district,
-            resourceValue?.line,
-            resourceValue?.postalCode,
-            resourceValue?.state,
-            resourceValue?.text,
-        ];
+    let op: (a: unknown, b: string) => boolean;
 
-        return addressFields.some((f) => f === value);
+    switch (modifier) {
+        case 'exact':
+            op = comparisons.exact;
+            break;
+        case 'contains':
+            op = comparisons.contains;
+            break;
+        case undefined:
+            op = comparisons.eq;
+            break;
+        default:
+            throw new Error(`The modifier ":${modifier}" is not supported`);
     }
 
-    return value === resourceValue;
+    let valuesFromResource: unknown[] = [];
+
+    if (typeof resourceValue === 'string') {
+        valuesFromResource = [resourceValue];
+    } else {
+        if (compiledSearchParam.path === 'name') {
+            // name is a special parameter.
+            valuesFromResource = [
+                resourceValue?.family,
+                resourceValue?.given,
+                resourceValue?.text,
+                resourceValue?.prefix,
+                resourceValue?.suffix,
+            ];
+        }
+
+        if (compiledSearchParam.path === 'address') {
+            // address is a special parameter.
+            valuesFromResource = [
+                resourceValue?.city,
+                resourceValue?.country,
+                resourceValue?.district,
+                resourceValue?.line,
+                resourceValue?.postalCode,
+                resourceValue?.state,
+                resourceValue?.text,
+            ];
+        }
+    }
+
+    return valuesFromResource.some((f) => op(f, value));
 };


### PR DESCRIPTION
Add support for modifiers. At this moment it only supports the same modifiers that our OpenSearch Implementation does (`:exact` and `:contains`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.