### PR TITLE
fix: chain parameters should inspect conditions to narrow down possible target types

### DIFF
--- a/src/QueryBuilder/chain.test.ts
+++ b/src/QueryBuilder/chain.test.ts
@@ -161,6 +161,26 @@ describe('parseChainedParameters', () => {
                     },
                 ],
             },
+            {
+                name: 'patient',
+                url: 'http://hl7.org/fhir/SearchParameter/Person-patient',
+                type: 'reference',
+                description: 'The Person links to this Patient',
+                base: 'Person',
+                target: ['Patient', 'Practitioner'],
+                compiled: [
+                    {
+                        resourceType: 'Person',
+                        path: 'link.target',
+                        condition: ['link.target', 'resolve', 'Observation'],
+                    },
+                    {
+                        resourceType: 'Person',
+                        path: 'link.target',
+                        condition: ['link.something', 'resolve', 'Observation'],
+                    },
+                ],
+            },
         ];
 
         const successCase: SearchParam = {
@@ -185,6 +205,6 @@ describe('parseChainedParameters', () => {
         };
 
         expect(getUniqueTarget(successCase)).toMatchInlineSnapshot(`"Patient"`);
-        errorCases.forEach((errorCase) => expect(getUniqueTarget(errorCase)).toMatchInlineSnapshot(`undefined`));
+        errorCases.forEach((errorCase) => expect(getUniqueTarget(errorCase)).toBeUndefined());
     });
 });

--- a/src/QueryBuilder/chain.test.ts
+++ b/src/QueryBuilder/chain.test.ts
@@ -62,6 +62,30 @@ describe('parseChainedParameters', () => {
               },
             ]
         `);
+
+        expect(
+            parseChainedParameters(fhirSearchParametersRegistry, 'DocumentReference', {
+                'patient.identifier': '2.16.840.1.113883.3.1579|8889154591540',
+            }),
+        ).toMatchInlineSnapshot(`
+            Array [
+              Object {
+                "chain": Array [
+                  Object {
+                    "resourceType": "Patient",
+                    "searchParam": "identifier",
+                  },
+                  Object {
+                    "resourceType": "DocumentReference",
+                    "searchParam": "patient",
+                  },
+                ],
+                "initialValue": Array [
+                  "2.16.840.1.113883.3.1579|8889154591540",
+                ],
+              },
+            ]
+        `);
     });
 
     test('invalid params', () => {

--- a/src/QueryBuilder/chain.test.ts
+++ b/src/QueryBuilder/chain.test.ts
@@ -4,8 +4,8 @@
  */
 
 import { InvalidSearchParameterError } from 'fhir-works-on-aws-interface';
-import parseChainedParameters from './chain';
-import { FHIRSearchParametersRegistry } from '../FHIRSearchParametersRegistry';
+import parseChainedParameters, { getUniqueTarget } from './chain';
+import { FHIRSearchParametersRegistry, SearchParam } from '../FHIRSearchParametersRegistry';
 
 const fhirSearchParametersRegistry = new FHIRSearchParametersRegistry('4.0.1');
 
@@ -62,30 +62,6 @@ describe('parseChainedParameters', () => {
               },
             ]
         `);
-
-        expect(
-            parseChainedParameters(fhirSearchParametersRegistry, 'DocumentReference', {
-                'patient.identifier': '2.16.840.1.113883.3.1579|8889154591540',
-            }),
-        ).toMatchInlineSnapshot(`
-            Array [
-              Object {
-                "chain": Array [
-                  Object {
-                    "resourceType": "Patient",
-                    "searchParam": "identifier",
-                  },
-                  Object {
-                    "resourceType": "DocumentReference",
-                    "searchParam": "patient",
-                  },
-                ],
-                "initialValue": Array [
-                  "2.16.840.1.113883.3.1579|8889154591540",
-                ],
-              },
-            ]
-        `);
     });
 
     test('invalid params', () => {
@@ -116,5 +92,100 @@ describe('parseChainedParameters', () => {
                 "Chained search parameter 'link' for resource type Patient points to multiple resource types, please specify.",
             ),
         );
+    });
+
+    test('search param with conditions that narrow down target type', () => {
+        expect(
+            parseChainedParameters(fhirSearchParametersRegistry, 'DocumentReference', {
+                'patient.identifier': '2.16.840.1.113883.3.1579|8889154591540',
+            }),
+        ).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "chain": Array [
+                Object {
+                  "resourceType": "Patient",
+                  "searchParam": "identifier",
+                },
+                Object {
+                  "resourceType": "DocumentReference",
+                  "searchParam": "patient",
+                },
+              ],
+              "initialValue": Array [
+                "2.16.840.1.113883.3.1579|8889154591540",
+              ],
+            },
+          ]
+      `);
+    });
+
+    test('get unique target edge cases', () => {
+        const errorCases: SearchParam[] = [
+            {
+                name: 'patient',
+                url: 'http://hl7.org/fhir/SearchParameter/Person-patient',
+                type: 'reference',
+                description: 'The Person links to this Patient',
+                base: 'Person',
+                target: ['Patient', 'Practitioner'],
+                compiled: [
+                    {
+                        resourceType: 'Person',
+                        path: 'link.target',
+                        condition: ['link.target', 'resolve', 'Patient'],
+                    },
+                    {
+                        resourceType: 'Person',
+                        path: 'link.target',
+                        condition: ['link.something', 'resolve', 'Practitioner'],
+                    },
+                ],
+            },
+            {
+                name: 'patient',
+                url: 'http://hl7.org/fhir/SearchParameter/Person-patient',
+                type: 'reference',
+                description: 'The Person links to this Patient',
+                base: 'Person',
+                target: ['Patient', 'Practitioner'],
+                compiled: [
+                    {
+                        resourceType: 'Person',
+                        path: 'link.target',
+                        condition: ['link.target', 'resolve', 'Patient'],
+                    },
+                    {
+                        resourceType: 'Person',
+                        path: 'xxx.target',
+                    },
+                ],
+            },
+        ];
+
+        const successCase: SearchParam = {
+            name: 'patient',
+            url: 'http://hl7.org/fhir/SearchParameter/Person-patient',
+            type: 'reference',
+            description: 'The Person links to this Patient',
+            base: 'Person',
+            target: ['Patient', 'Practitioner'],
+            compiled: [
+                {
+                    resourceType: 'Person',
+                    path: 'link.target',
+                    condition: ['link.target', 'resolve', 'Patient'],
+                },
+                {
+                    resourceType: 'Person',
+                    path: 'link.target',
+                    condition: ['link.something', 'resolve', 'Patient'],
+                },
+            ],
+        };
+
+        expect(getUniqueTarget(successCase)).toMatchInlineSnapshot(`"Patient"`);
+        expect(getUniqueTarget(errorCases[0])).toMatchInlineSnapshot(`undefined`);
+        expect(getUniqueTarget(errorCases[1])).toMatchInlineSnapshot(`undefined`);
     });
 });

--- a/src/QueryBuilder/chain.test.ts
+++ b/src/QueryBuilder/chain.test.ts
@@ -185,7 +185,6 @@ describe('parseChainedParameters', () => {
         };
 
         expect(getUniqueTarget(successCase)).toMatchInlineSnapshot(`"Patient"`);
-        expect(getUniqueTarget(errorCases[0])).toMatchInlineSnapshot(`undefined`);
-        expect(getUniqueTarget(errorCases[1])).toMatchInlineSnapshot(`undefined`);
+        errorCases.forEach((errorCase) => expect(getUniqueTarget(errorCase)).toMatchInlineSnapshot(`undefined`));
     });
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,7 @@ export const ITERATIVE_INCLUSION_PARAMETERS = ['_include:iterate', '_revinclude:
 export const INCLUSION_PARAMETERS = ['_include', '_revinclude', ...ITERATIVE_INCLUSION_PARAMETERS];
 export const UNSUPPORTED_GENERAL_PARAMETERS = ['_format', '_pretty', '_summary', '_elements'];
 export const SORT_PARAMETER = '_sort';
+export const COMPILED_CONDITION_OPERATOR_RESOLVE = 'resolve';
 export const NON_SEARCHABLE_PARAMETERS = [
     SORT_PARAMETER,
     SEARCH_PAGINATION_PARAMS.PAGES_OFFSET,


### PR DESCRIPTION
Issue #166, if available:

Description of changes:
Added logic for parsing compiledSearchParamaters' conditions to narrow down target Resource types when there are multiple, if possible.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.