### PR TITLE
feat: add StreamSubscriptionMatcher partial implementation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,11 @@ module.exports = {
         'no-empty-function': 'off',
         '@typescript-eslint/no-empty-function': 'error',
         'import/no-extraneous-dependencies': ['error', { devDependencies: ['**/*.test.ts', 'scripts/**/*.js'] }],
+        // @types/aws-lambda is special since aws-lambda is not the name of a package that we take as a dependency.
+        // Making eslint recognize it would require several additional plugins and it's not worth setting it up right now.
+        // See https://github.com/typescript-eslint/typescript-eslint/issues/1624
+        // eslint-disable-next-line import/no-unresolved
+        'import/no-unresolved': ['error', { ignore: ['aws-lambda'] }],
         'no-shadow': 'off', // replaced by ts-eslint rule below
         '@typescript-eslint/no-shadow': 'error',
     },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@elastic/elasticsearch": "7.13",
+    "@types/aws-lambda": "^8.10.92",
     "aws-elasticsearch-connector": "^8.2.0",
     "aws-sdk": "^2.1000.0",
     "date-fns": "^2.19.0",
@@ -37,7 +38,7 @@
     "flat": "^5.0.2",
     "lodash": "^4.17.20",
     "nearley": "^2.20.0",
-    "qs": "^6.10.2"
+    "qs": "^6.10.3"
   },
   "devDependencies": {
     "@elastic/elasticsearch-mock": "^0.3.1",

--- a/src/FhirQueryParser/index.ts
+++ b/src/FhirQueryParser/index.ts
@@ -5,6 +5,7 @@
  */
 import { isEmpty } from 'lodash';
 import { InvalidSearchParameterError } from 'fhir-works-on-aws-interface';
+import * as qs from 'qs';
 import { FHIRSearchParametersRegistry, SearchParam } from '../FHIRSearchParametersRegistry';
 import { isChainedParameter, normalizeQueryParams, parseSearchModifiers } from './util';
 import getComponentLogger from '../loggerBuilder';
@@ -249,4 +250,19 @@ export const parseQuery = (
         ...(!isEmpty(chainedSearchParams) && { chainedSearchParams }),
         ...(!isEmpty(otherParams) && { otherParams }),
     };
+};
+
+/**
+ * Parse and validate the search query parameters.
+ * @param fhirSearchParametersRegistry - instance of FHIRSearchParametersRegistry
+ * @param searchCriteria - Search criteria without the base url. Example: "Observation?code=http://loinc.org|1975-2"
+ */
+export const parseQueryString = (
+    fhirSearchParametersRegistry: FHIRSearchParametersRegistry,
+    searchCriteria: string,
+): ParsedFhirQueryParams => {
+    const questionMarkIndex = searchCriteria.indexOf('?') === -1 ? searchCriteria.length : searchCriteria.indexOf('?');
+    const resourceType = searchCriteria.substring(0, questionMarkIndex);
+    const queryString = searchCriteria.substring(questionMarkIndex + 1);
+    return parseQuery(fhirSearchParametersRegistry, resourceType, qs.parse(queryString));
 };

--- a/src/InMemoryMatcher/index.ts
+++ b/src/InMemoryMatcher/index.ts
@@ -12,7 +12,7 @@ import {
     QueryParam,
     StringLikeSearchValue,
 } from '../FhirQueryParser';
-import { CompiledSearchParam, SearchParam } from '../FHIRSearchParametersRegistry';
+import { CompiledSearchParam } from '../FHIRSearchParametersRegistry';
 import { numberMatch } from './matchers/numberMatch';
 import { dateMatch } from './matchers/dateMatch';
 import { getAllValuesForFHIRPath } from '../getAllValuesForFHIRPath';

--- a/src/StreamSubscriptionMatcher/AsyncRefreshCache.test.ts
+++ b/src/StreamSubscriptionMatcher/AsyncRefreshCache.test.ts
@@ -1,0 +1,50 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { AsyncRefreshCache } from './AsyncRefreshCache';
+
+describe('AsyncRefreshCache', () => {
+    test('should cache the result of loadFn', async () => {
+        jest.useFakeTimers();
+        jest.clearAllTimers();
+        const loadFn = jest
+            .fn()
+            .mockReturnValueOnce(Promise.resolve('initial value'))
+            .mockReturnValueOnce(Promise.resolve('latest value'));
+
+        const a = new AsyncRefreshCache<String>(loadFn, 1000);
+
+        await expect(a.get()).resolves.toMatchInlineSnapshot(`"initial value"`);
+        await expect(a.get()).resolves.toMatchInlineSnapshot(`"initial value"`);
+        expect(loadFn).toHaveBeenCalledTimes(1);
+
+        jest.advanceTimersByTime(1000);
+
+        await expect(a.get()).resolves.toMatchInlineSnapshot(`"latest value"`);
+        await expect(a.get()).resolves.toMatchInlineSnapshot(`"latest value"`);
+        expect(loadFn).toHaveBeenCalledTimes(2);
+
+        a.stop();
+    });
+
+    test('should call loadFn periodically', async () => {
+        jest.useFakeTimers();
+        jest.clearAllTimers();
+        const loadFn = jest.fn(async () => 'hello');
+
+        const a = new AsyncRefreshCache<String>(loadFn, 1000);
+
+        expect(loadFn).toHaveBeenCalledTimes(1);
+
+        jest.advanceTimersByTime(1000);
+        expect(loadFn).toHaveBeenCalledTimes(2);
+
+        jest.advanceTimersByTime(1000);
+        expect(loadFn).toHaveBeenCalledTimes(3);
+
+        a.stop();
+    });
+});

--- a/src/StreamSubscriptionMatcher/AsyncRefreshCache.ts
+++ b/src/StreamSubscriptionMatcher/AsyncRefreshCache.ts
@@ -1,0 +1,34 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+/**
+ * Periodically calls an async fn and keeps its latest response value cached.
+ */
+// eslint-disable-next-line import/prefer-default-export
+export class AsyncRefreshCache<T> {
+    private values: Promise<T>;
+
+    // eslint-disable-next-line no-undef
+    private readonly interval: NodeJS.Timeout;
+
+    /**
+     * @param loadFn - async function to be called periodically
+     * @param period - wait time in seconds before calling `loadFn` again
+     */
+    constructor(loadFn: () => Promise<T>, period = 3000) {
+        this.values = loadFn();
+        this.interval = setInterval(() => {
+            this.values = loadFn();
+        }, period);
+    }
+
+    async get(): Promise<T> {
+        return this.values;
+    }
+
+    stop() {
+        clearInterval(this.interval);
+    }
+}

--- a/src/StreamSubscriptionMatcher/StreamSubscriptionMatcher.ts
+++ b/src/StreamSubscriptionMatcher/StreamSubscriptionMatcher.ts
@@ -58,11 +58,17 @@ export class StreamSubscriptionMatcher {
         this.topicArn = topicArn;
         this.fhirSearchParametersRegistry = new FHIRSearchParametersRegistry(fhirVersion, compiledImplementationGuides);
 
-        this.activeSubscriptions = new AsyncRefreshCache<Subscription[]>(async () =>
-            (await this.persistence.getActiveSubscriptions({})).map((resource) =>
-                parseSubscription(resource, this.fhirSearchParametersRegistry),
-            ),
-        );
+        this.activeSubscriptions = new AsyncRefreshCache<Subscription[]>(async () => {
+            console.log('Refreshing cache of active subscriptions...');
+
+            const activeSubscriptions: Subscription[] = (await this.persistence.getActiveSubscriptions({})).map(
+                (resource) => parseSubscription(resource, this.fhirSearchParametersRegistry),
+            );
+
+            console.log(`found ${activeSubscriptions.length} active subscriptions`);
+
+            return activeSubscriptions;
+        });
     }
 
     async match(dynamoDBStreamEvent: DynamoDBStreamEvent): Promise<void> {

--- a/src/StreamSubscriptionMatcher/StreamSubscriptionMatcher.ts
+++ b/src/StreamSubscriptionMatcher/StreamSubscriptionMatcher.ts
@@ -1,0 +1,92 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { DynamoDBStreamEvent } from 'aws-lambda/trigger/dynamodb-stream';
+import { chunk } from 'lodash';
+import { FhirVersion, Persistence } from 'fhir-works-on-aws-interface';
+import {
+    buildNotification,
+    filterOutIneligibleResources,
+    parseSubscription,
+    Subscription,
+    SubscriptionNotification,
+} from './subscriptions';
+import { matchParsedFhirQueryParams } from '../InMemoryMatcher';
+import { FHIRSearchParametersRegistry } from '../FHIRSearchParametersRegistry';
+import { AsyncRefreshCache } from './AsyncRefreshCache';
+
+const SNS_MAX_BATCH_SIZE = 10;
+const matchSubscription = (subscription: Subscription, resource: Record<string, any>): boolean => {
+    return (
+        // eslint-disable-next-line no-underscore-dangle
+        subscription.tenantId === resource._tenantId &&
+        matchParsedFhirQueryParams(subscription.parsedCriteria, resource)
+    );
+};
+
+/**
+ * This class matches DynamoDBStreamEvents against the active Subscriptions and publishes SNS messages for each match.
+ */
+// eslint-disable-next-line import/prefer-default-export
+export class StreamSubscriptionMatcher {
+    private readonly fhirSearchParametersRegistry: FHIRSearchParametersRegistry;
+
+    private readonly persistence: Persistence;
+
+    private readonly topicArn: string;
+
+    private activeSubscriptions: AsyncRefreshCache<Subscription[]>;
+
+    /**
+     * @param persistence - Persistence implementation. Used to fetch the active Subscriptions
+     * @param topicArn - arn of the SNS topic where notifications will be sent
+     * @param options.fhirVersion - FHIR version. Used to determine how to interpret search parameters
+     * @param options.compiledImplementationGuides - Additional search parameters from implementation guides
+     */
+    constructor(
+        persistence: Persistence,
+        topicArn: string,
+        {
+            fhirVersion = '4.0.1',
+            compiledImplementationGuides,
+        }: { enableMultiTenancy?: boolean; fhirVersion?: FhirVersion; compiledImplementationGuides?: any } = {},
+    ) {
+        this.persistence = persistence;
+        this.topicArn = topicArn;
+        this.fhirSearchParametersRegistry = new FHIRSearchParametersRegistry(fhirVersion, compiledImplementationGuides);
+
+        this.activeSubscriptions = new AsyncRefreshCache<Subscription[]>(async () =>
+            (await this.persistence.getActiveSubscriptions({})).map((resource) =>
+                parseSubscription(resource, this.fhirSearchParametersRegistry),
+            ),
+        );
+    }
+
+    async match(dynamoDBStreamEvent: DynamoDBStreamEvent): Promise<void> {
+        const eligibleResources = filterOutIneligibleResources(dynamoDBStreamEvent);
+        const subscriptionNotifications: SubscriptionNotification[] = (await this.activeSubscriptions.get()).flatMap(
+            (subscription) => {
+                return eligibleResources
+                    .filter((resource) => matchSubscription(subscription, resource))
+                    .map((resource) => buildNotification(subscription, resource));
+            },
+        );
+
+        console.log(
+            'Summary of notifications:',
+            JSON.stringify(
+                subscriptionNotifications.map((s) => ({
+                    subscriptionId: s.subscriptionId,
+                    resourceId: s.matchedResource.id,
+                })),
+            ),
+        );
+
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const chunks: SubscriptionNotification[][] = chunk(subscriptionNotifications, SNS_MAX_BATCH_SIZE);
+        // TODO: use publishBatch to send SNS messages.
+    }
+}

--- a/src/StreamSubscriptionMatcher/index.ts
+++ b/src/StreamSubscriptionMatcher/index.ts
@@ -1,10 +1,7 @@
 /*
  *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  SPDX-License-Identifier: Apache-2.0
+ *
  */
 
-export * from './elasticSearchService';
-export * from './implementationGuides';
-export * from './searchMappings';
-export * from './searchMappingsManager';
 export * from './StreamSubscriptionMatcher';

--- a/src/StreamSubscriptionMatcher/subscriptions.test.ts
+++ b/src/StreamSubscriptionMatcher/subscriptions.test.ts
@@ -1,0 +1,165 @@
+import { DynamoDBStreamEvent } from 'aws-lambda/trigger/dynamodb-stream';
+import { buildNotification, filterOutIneligibleResources, parseSubscription } from './subscriptions';
+import { FHIRSearchParametersRegistry } from '../FHIRSearchParametersRegistry';
+
+describe('filterOutIneligibleResources', () => {
+    const dynamoDBStreamEvent = (): DynamoDBStreamEvent => ({
+        Records: [
+            {
+                eventID: '3db0558e9432f45190f2adfae4bdfaed',
+                eventName: 'INSERT',
+                eventVersion: '1.1',
+                eventSource: 'aws:dynamodb',
+                awsRegion: 'us-west-2',
+                dynamodb: {
+                    ApproximateCreationDateTime: 1629925579,
+                    Keys: {
+                        vid: {
+                            N: '1',
+                        },
+                        id: {
+                            S: 'b75eef29-4d3b-4454-ba27-6436e55d6a29',
+                        },
+                    },
+                    NewImage: {
+                        vid: {
+                            N: '1',
+                        },
+                        documentStatus: {
+                            S: 'AVAILABLE',
+                        },
+                        id: {
+                            S: 'b75eef29-4d3b-4454-ba27-6436e55d6a29',
+                        },
+                        resourceType: {
+                            S: 'Patient',
+                        },
+                    },
+                    SequenceNumber: '330610500000000075165486233',
+                    SizeBytes: 322,
+                    StreamViewType: 'NEW_AND_OLD_IMAGES',
+                },
+                eventSourceARN:
+                    'arn:aws:dynamodb:us-west-2:494110835610:table/resource-db-dev/stream/2021-06-17T09:08:31.388',
+            },
+        ],
+    });
+
+    test('good event', () => {
+        expect(filterOutIneligibleResources(dynamoDBStreamEvent())).toMatchInlineSnapshot(`
+            Array [
+              Object {
+                "documentStatus": "AVAILABLE",
+                "id": "b75eef29-4d3b-4454-ba27-6436e55d6a29",
+                "resourceType": "Patient",
+                "vid": 1,
+              },
+            ]
+        `);
+    });
+
+    describe('Ineligible Resources', () => {
+        test('REMOVE event name', () => {
+            const event = dynamoDBStreamEvent();
+            event.Records[0].eventName = 'REMOVE';
+            expect(filterOutIneligibleResources(event)).toMatchInlineSnapshot(`Array []`);
+        });
+
+        test('documentStatus is not active', () => {
+            const event = dynamoDBStreamEvent();
+            event.Records[0].dynamodb!.NewImage!.documentStatus.S = 'LOCKED';
+            expect(filterOutIneligibleResources(event)).toMatchInlineSnapshot(`Array []`);
+        });
+    });
+});
+
+describe('buildNotification', () => {
+    test('maps fields correctly ', () => {
+        const notification = buildNotification(
+            {
+                channelType: 'rest-hook',
+                channelHeader: ['SomeHeader: token-abc-123'],
+                channelPayload: 'application/fhir+json',
+                endpoint: 'https://endpoint.com',
+                parsedCriteria: { searchParams: [], resourceType: 'DocumentReference' },
+                subscriptionId: '111',
+                tenantId: 't1',
+            },
+            {
+                meta: {
+                    lastUpdated: '2021-10-08T12:37:44.998Z',
+                    versionId: '1',
+                },
+                id: '222',
+                resourceType: 'DocumentReference',
+            },
+        );
+
+        expect(notification).toMatchInlineSnapshot(`
+            Object {
+              "channelHeader": Array [
+                "SomeHeader: token-abc-123",
+              ],
+              "channelPayload": "application/fhir+json",
+              "channelType": "rest-hook",
+              "endpoint": "https://endpoint.com",
+              "matchedResource": Object {
+                "id": "222",
+                "lastUpdated": "2021-10-08T12:37:44.998Z",
+                "versionId": "1",
+              },
+              "subscriptionId": "111",
+              "tenantId": undefined,
+            }
+        `);
+    });
+});
+
+describe('parseSubscription', () => {
+    test('maps fields correctly', () => {
+        expect(
+            parseSubscription(
+                {
+                    resourceType: 'Subscription',
+                    id: 'example',
+                    text: {
+                        status: 'generated',
+                        div: '<div xmlns="http://www.w3.org/1999/xhtml">[Put rendering here]</div>',
+                    },
+                    status: 'requested',
+                    contact: [
+                        {
+                            system: 'phone',
+                            value: 'ext 4123',
+                        },
+                    ],
+                    end: '2021-01-01T00:00:00Z',
+                    reason: 'Monitor new neonatal function',
+                    criteria: 'Observation?',
+                    channel: {
+                        type: 'rest-hook',
+                        endpoint: 'https://biliwatch.com/customers/mount-auburn-miu/on-result',
+                        payload: 'application/fhir+json',
+                        header: ['SomeHeader: token-abc-123'],
+                    },
+                },
+                new FHIRSearchParametersRegistry('4.0.1'),
+            ),
+        ).toMatchInlineSnapshot(`
+            Object {
+              "channelHeader": Array [
+                "SomeHeader: token-abc-123",
+              ],
+              "channelPayload": "application/fhir+json",
+              "channelType": "rest-hook",
+              "endpoint": "https://biliwatch.com/customers/mount-auburn-miu/on-result",
+              "parsedCriteria": Object {
+                "resourceType": "Observation",
+                "searchParams": Array [],
+              },
+              "subscriptionId": "example",
+              "tenantId": undefined,
+            }
+        `);
+    });
+});

--- a/src/StreamSubscriptionMatcher/subscriptions.test.ts
+++ b/src/StreamSubscriptionMatcher/subscriptions.test.ts
@@ -106,6 +106,7 @@ describe('buildNotification', () => {
               "matchedResource": Object {
                 "id": "222",
                 "lastUpdated": "2021-10-08T12:37:44.998Z",
+                "resourceType": "DocumentReference",
                 "versionId": "1",
               },
               "subscriptionId": "111",

--- a/src/StreamSubscriptionMatcher/subscriptions.ts
+++ b/src/StreamSubscriptionMatcher/subscriptions.ts
@@ -2,6 +2,9 @@ import { DynamoDBRecord, DynamoDBStreamEvent } from 'aws-lambda/trigger/dynamodb
 import AWS from 'aws-sdk';
 import { FHIRSearchParametersRegistry } from '../FHIRSearchParametersRegistry';
 import { ParsedFhirQueryParams, parseQueryString } from '../FhirQueryParser';
+import getComponentLogger from '../loggerBuilder';
+
+const logger = getComponentLogger();
 
 export interface Subscription {
     subscriptionId: string;
@@ -58,7 +61,9 @@ export const filterOutIneligibleResources = (dynamoDBStreamEvent: DynamoDBStream
             return [];
         }
         if (dynamoDbRecord.dynamodb?.NewImage === undefined) {
-            console.log('dynamodb.NewImage is missing from event. Is your stream correctly configured?');
+            logger.error(
+                'dynamodb.NewImage is missing from event. The stream event will be dropped. Is your stream correctly configured?',
+            );
             return [];
         }
         const resource = AWS.DynamoDB.Converter.unmarshall(dynamoDbRecord.dynamodb.NewImage);

--- a/src/StreamSubscriptionMatcher/subscriptions.ts
+++ b/src/StreamSubscriptionMatcher/subscriptions.ts
@@ -41,7 +41,7 @@ export const buildNotification = (
     endpoint: subscription.endpoint,
     matchedResource: {
         id: resource.id,
-        resourceType: resource?.resourceType,
+        resourceType: resource.resourceType,
         lastUpdated: resource.meta?.lastUpdated,
         versionId: resource.meta?.versionId,
     },

--- a/src/StreamSubscriptionMatcher/subscriptions.ts
+++ b/src/StreamSubscriptionMatcher/subscriptions.ts
@@ -1,0 +1,85 @@
+import { DynamoDBRecord, DynamoDBStreamEvent } from 'aws-lambda/trigger/dynamodb-stream';
+import AWS from 'aws-sdk';
+import { FHIRSearchParametersRegistry } from '../FHIRSearchParametersRegistry';
+import { ParsedFhirQueryParams, parseQueryString } from '../FhirQueryParser';
+
+export interface Subscription {
+    subscriptionId: string;
+    tenantId?: string;
+    channelType: string;
+    channelHeader: string[];
+    channelPayload: string;
+    endpoint: string;
+    parsedCriteria: ParsedFhirQueryParams;
+}
+
+export interface SubscriptionNotification {
+    subscriptionId: string;
+    tenantId?: string;
+    channelType: string;
+    endpoint: string;
+    channelPayload: string;
+    channelHeader: string[];
+    matchedResource: {
+        id: string;
+        versionId: string;
+        lastUpdated: string;
+    };
+}
+
+export const buildNotification = (
+    subscription: Subscription,
+    resource: Record<string, any>,
+): SubscriptionNotification => ({
+    subscriptionId: subscription.subscriptionId,
+    // eslint-disable-next-line no-underscore-dangle
+    tenantId: resource._tenantId,
+    channelType: subscription.channelType,
+    channelHeader: subscription.channelHeader,
+    channelPayload: subscription.channelPayload,
+    endpoint: subscription.endpoint,
+    matchedResource: {
+        id: resource.id,
+        lastUpdated: resource.meta?.lastUpdated,
+        versionId: resource.meta?.versionId,
+    },
+});
+
+const isCreateOrUpdate = (dynamoDBRecord: DynamoDBRecord): boolean => {
+    return dynamoDBRecord.eventName === 'INSERT' || dynamoDBRecord.eventName === 'MODIFY';
+};
+
+export const filterOutIneligibleResources = (dynamoDBStreamEvent: DynamoDBStreamEvent): Record<string, any>[] => {
+    return dynamoDBStreamEvent.Records.flatMap((dynamoDbRecord) => {
+        if (!isCreateOrUpdate(dynamoDbRecord)) {
+            // Subscriptions never match deleted resources
+            return [];
+        }
+        if (dynamoDbRecord.dynamodb?.NewImage === undefined) {
+            console.log('dynamodb.NewImage is missing from event. Is your stream correctly configured?');
+            return [];
+        }
+        const resource = AWS.DynamoDB.Converter.unmarshall(dynamoDbRecord.dynamodb.NewImage);
+
+        if (resource.documentStatus !== 'AVAILABLE') {
+            return [];
+        }
+
+        return [resource];
+    });
+};
+export const parseSubscription = (
+    resource: Record<string, any>,
+    fhirSearchParametersRegistry: FHIRSearchParametersRegistry,
+): Subscription => {
+    return {
+        channelType: resource?.channel?.type,
+        channelHeader: resource?.channel?.header || [],
+        channelPayload: resource?.channel?.payload,
+        endpoint: resource?.channel?.endpoint,
+        parsedCriteria: parseQueryString(fhirSearchParametersRegistry, resource?.criteria),
+        subscriptionId: resource?.id,
+        // eslint-disable-next-line no-underscore-dangle
+        tenantId: resource?._tenantId,
+    };
+};

--- a/src/StreamSubscriptionMatcher/subscriptions.ts
+++ b/src/StreamSubscriptionMatcher/subscriptions.ts
@@ -22,6 +22,7 @@ export interface SubscriptionNotification {
     channelHeader: string[];
     matchedResource: {
         id: string;
+        resourceType: string;
         versionId: string;
         lastUpdated: string;
     };
@@ -40,6 +41,7 @@ export const buildNotification = (
     endpoint: subscription.endpoint,
     matchedResource: {
         id: resource.id,
+        resourceType: resource?.resourceType,
         lastUpdated: resource.meta?.lastUpdated,
         versionId: resource.meta?.versionId,
     },

--- a/src/elasticSearchService.ts
+++ b/src/elasticSearchService.ts
@@ -5,7 +5,6 @@
 
 /* eslint-disable no-underscore-dangle */
 import URL from 'url';
-import * as qs from 'qs';
 
 import { ResponseError } from '@elastic/elasticsearch/lib/errors';
 import { partition, merge, isEmpty } from 'lodash';
@@ -33,7 +32,7 @@ import {
 import { buildIncludeQueries, buildRevIncludeQueries } from './searchInclusions';
 import { FHIRSearchParametersRegistry } from './FHIRSearchParametersRegistry';
 import { buildQueryForAllSearchParameters, buildSortClause } from './QueryBuilder';
-import { parseQuery } from './FhirQueryParser';
+import { parseQueryString } from './FhirQueryParser';
 import parseChainedParameters, { ChainParameter } from './QueryBuilder/chain';
 import getComponentLogger from './loggerBuilder';
 
@@ -522,14 +521,9 @@ export class ElasticSearchService implements Search {
     }
 
     validateSubscriptionSearchCriteria(searchCriteria: string): void {
-        const questionMarkIndex =
-            searchCriteria.indexOf('?') === -1 ? searchCriteria.length : searchCriteria.indexOf('?');
-        const resourceType = searchCriteria.substring(0, questionMarkIndex);
-        const queryString = searchCriteria.substring(questionMarkIndex + 1);
-        const { inclusionSearchParams, chainedSearchParams, otherParams } = parseQuery(
+        const { inclusionSearchParams, chainedSearchParams, otherParams } = parseQueryString(
             this.fhirSearchParametersRegistry,
-            resourceType,
-            qs.parse(queryString),
+            searchCriteria,
         );
         if (inclusionSearchParams || chainedSearchParams || otherParams) {
             throw new InvalidSearchParameterError(

--- a/yarn.lock
+++ b/yarn.lock
@@ -599,6 +599,11 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@types/aws-lambda@^8.10.92":
+  version "8.10.92"
+  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.92.tgz#645f769ff88b8eba1acd35542695ac322c7757c4"
+  integrity sha512-dB14TltT1SNq73z3MaZfKyyBZ37NAgAFl8jze59bisR4fJ6pB6AYGxItHFkooZbN7UcVJX/cFudM4p8wp1W4rA==
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.16"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.16.tgz#bc12c74b7d65e82d29876b5d0baf5c625ac58702"
@@ -4452,10 +4457,10 @@ q@^1.5.1:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
-qs@^6.10.2:
-  version "6.10.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.2.tgz#c1431bea37fc5b24c5bdbafa20f16bdf2a4b9ffe"
-  integrity sha512-mSIdjzqznWgfd4pMii7sHtaYF8rx8861hBO80SraY5GT0XQibWZWJSid0avzHGkDIZLImux2S5mXO0Hfct2QCw==
+qs@^6.10.3:
+  version "6.10.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.3.tgz#d6cde1b2ffca87b5aa57889816c5f81535e22e8e"
+  integrity sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==
   dependencies:
     side-channel "^1.0.4"
 


### PR DESCRIPTION
`StreamSubscriptionMatcher` will be the main class in the `SubscriptionMatcherLambda`. Right now it does the following:
- Keep a cache of active subscriptions and refresh it asynchronously every 30 seconds
- Match all stream events against all active subscriptions

Next steps are to actually publish SNS messages when a match is found

**Note:** tests are failing since tthis PR is based on unreleased changes from the interface/persistence package( the new `getActiveSubscriptions` method that is on a feature branch)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.