### PR TITLE
fix: actually enable token and uri matching

### DIFF
--- a/src/InMemoryMatcher/index.ts
+++ b/src/InMemoryMatcher/index.ts
@@ -11,6 +11,7 @@ import {
     QuantitySearchValue,
     QueryParam,
     StringLikeSearchValue,
+    TokenSearchValue,
 } from '../FhirQueryParser';
 import { CompiledSearchParam } from '../FHIRSearchParametersRegistry';
 import { numberMatch } from './matchers/numberMatch';
@@ -20,6 +21,8 @@ import { stringMatch } from './matchers/stringMatch';
 import { quantityMatch } from './matchers/quantityMatch';
 import { referenceMatch } from './matchers/referenceMatcher';
 import { ReferenceSearchValue } from '../FhirQueryParser/typeParsers/referenceParser';
+import { tokenMatch } from './matchers/tokenMatch';
+import { uriMatch } from './matchers/uriMatch';
 
 const typeMatcher = (
     queryParam: QueryParam,
@@ -45,13 +48,13 @@ const typeMatcher = (
                 fhirServiceBaseUrl,
             });
         case 'token':
-            break;
+            return tokenMatch(searchValue as TokenSearchValue, resourceValue);
         case 'composite':
             break;
         case 'special':
             break;
         case 'uri':
-            break;
+            return uriMatch(searchValue as StringLikeSearchValue, resourceValue);
         default:
             // eslint-disable-next-line no-case-declarations
             const exhaustiveCheck: never = searchParam.type;

--- a/src/InMemoryMatcher/matchers/tokenMatch.test.ts
+++ b/src/InMemoryMatcher/matchers/tokenMatch.test.ts
@@ -128,6 +128,28 @@ describe('tokenMatch', () => {
                     ),
                 ).toBe(true);
             });
+
+            test('code type', () => {
+                expect(
+                    tokenMatch(
+                        {
+                            code: 'female',
+                            explicitNoSystemProperty: false,
+                        },
+                        'female',
+                    ),
+                ).toBe(true);
+
+                expect(
+                    tokenMatch(
+                        {
+                            code: 'female',
+                            explicitNoSystemProperty: false,
+                        },
+                        'male',
+                    ),
+                ).toBe(false);
+            });
         });
     });
 


### PR DESCRIPTION
This was missing from when `tokenMatch` and `uriMatch` were added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.