### PR TITLE
fix: strip tenantId from id. increase subscription refresh timeout

### DIFF
--- a/src/StreamSubscriptionMatcher/StreamSubscriptionMatcher.ts
+++ b/src/StreamSubscriptionMatcher/StreamSubscriptionMatcher.ts
@@ -20,6 +20,7 @@ import { AsyncRefreshCache } from './AsyncRefreshCache';
 import getComponentLogger from '../loggerBuilder';
 
 const SNS_MAX_BATCH_SIZE = 10;
+const ACTIVE_SUBSCRIPTIONS_CACHE_REFRESH_TIMEOUT = 30_000;
 
 const logger = getComponentLogger();
 
@@ -72,7 +73,7 @@ export class StreamSubscriptionMatcher {
             logger.info(`found ${activeSubscriptions.length} active subscriptions`);
 
             return activeSubscriptions;
-        });
+        }, ACTIVE_SUBSCRIPTIONS_CACHE_REFRESH_TIMEOUT);
     }
 
     async match(dynamoDBStreamEvent: DynamoDBStreamEvent): Promise<void> {

--- a/src/StreamSubscriptionMatcher/StreamSubscriptionMatcher.ts
+++ b/src/StreamSubscriptionMatcher/StreamSubscriptionMatcher.ts
@@ -20,7 +20,7 @@ import { AsyncRefreshCache } from './AsyncRefreshCache';
 import getComponentLogger from '../loggerBuilder';
 
 const SNS_MAX_BATCH_SIZE = 10;
-const ACTIVE_SUBSCRIPTIONS_CACHE_REFRESH_TIMEOUT = 30_000;
+const ACTIVE_SUBSCRIPTIONS_CACHE_REFRESH_TIMEOUT = 60_000;
 
 const logger = getComponentLogger();
 

--- a/src/StreamSubscriptionMatcher/subscriptions.test.ts
+++ b/src/StreamSubscriptionMatcher/subscriptions.test.ts
@@ -114,6 +114,49 @@ describe('buildNotification', () => {
             }
         `);
     });
+
+    test('multi-tenant id', () => {
+        const notification = buildNotification(
+            {
+                channelType: 'rest-hook',
+                channelHeader: ['SomeHeader: token-abc-123'],
+                channelPayload: 'application/fhir+json',
+                endpoint: 'https://endpoint.com',
+                parsedCriteria: { searchParams: [], resourceType: 'DocumentReference' },
+                subscriptionId: '111',
+                tenantId: 't1',
+            },
+            {
+                meta: {
+                    lastUpdated: '2021-10-08T12:37:44.998Z',
+                    versionId: '1',
+                },
+                _tenantId: 't1',
+                id: 't1|222',
+                _id: '222',
+                resourceType: 'DocumentReference',
+            },
+        );
+
+        expect(notification).toMatchInlineSnapshot(`
+            Object {
+              "channelHeader": Array [
+                "SomeHeader: token-abc-123",
+              ],
+              "channelPayload": "application/fhir+json",
+              "channelType": "rest-hook",
+              "endpoint": "https://endpoint.com",
+              "matchedResource": Object {
+                "id": "222",
+                "lastUpdated": "2021-10-08T12:37:44.998Z",
+                "resourceType": "DocumentReference",
+                "versionId": "1",
+              },
+              "subscriptionId": "111",
+              "tenantId": "t1",
+            }
+        `);
+    });
 });
 
 describe('parseSubscription', () => {

--- a/src/StreamSubscriptionMatcher/subscriptions.ts
+++ b/src/StreamSubscriptionMatcher/subscriptions.ts
@@ -43,7 +43,8 @@ export const buildNotification = (
     channelPayload: subscription.channelPayload,
     endpoint: subscription.endpoint,
     matchedResource: {
-        id: resource.id,
+        // eslint-disable-next-line no-underscore-dangle
+        id: resource._tenantId ? resource._id : resource.id,
         resourceType: resource.resourceType,
         lastUpdated: resource.meta?.lastUpdated,
         versionId: resource.meta?.versionId,


### PR DESCRIPTION
Description of changes:
- Set active subscriptions refresh rate to 1 minute
- Strip tenantId from id (multi-tenant resources have an id in DDB like `<tenantId>|<resourceId>`) 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.