### PR TITLE
feat: Validate inclusion params before searching

### DIFF
--- a/src/FHIRSearchParametersRegistry/index.ts
+++ b/src/FHIRSearchParametersRegistry/index.ts
@@ -175,25 +175,27 @@ export class FHIRSearchParametersRegistry {
      * @param resourceType
      * @param name
      * @param targetResourceType
-     * @return the matching SearchParam or undefined if there's no match
+     * @return the matching SearchParam or error message if there's no match
      */
     getReferenceSearchParameter(
         resourceType: string,
         name: string,
         targetResourceType?: string,
-    ): SearchParam | undefined {
+    ): SearchParam | { error: string } {
         const searchParam = this.getSearchParameter(resourceType, name);
 
         if (searchParam === undefined) {
-            return undefined;
+            return { error: `Search parameter ${name} does not exist in resource ${resourceType}` };
         }
 
         if (searchParam.type !== 'reference') {
-            return undefined;
+            return { error: `Search parameter ${name} is not of type reference in resource ${resourceType}` };
         }
 
         if (targetResourceType !== undefined && !searchParam.target?.includes(targetResourceType)) {
-            return undefined;
+            return {
+                error: `Search parameter ${name} in resource ${resourceType} does not point to target resource type ${targetResourceType}`,
+            };
         }
         return searchParam;
     }

--- a/src/FhirQueryParser/index.test.ts
+++ b/src/FhirQueryParser/index.test.ts
@@ -359,14 +359,24 @@ describe('queryParser', () => {
         });
         expect(q).toMatchInlineSnapshot(`
             Object {
-              "inclusionSearchParams": Object {
-                "_include": Array [
-                  "MedicationRequest:patient",
-                ],
-                "_revinclude": Array [
-                  "Provenance:target",
-                ],
-              },
+              "inclusionSearchParams": Array [
+                Object {
+                  "isWildcard": false,
+                  "path": "subject",
+                  "searchParameter": "patient",
+                  "sourceResource": "MedicationRequest",
+                  "targetResourceType": undefined,
+                  "type": "_include",
+                },
+                Object {
+                  "isWildcard": false,
+                  "path": "target",
+                  "searchParameter": "target",
+                  "sourceResource": "Provenance",
+                  "targetResourceType": undefined,
+                  "type": "_revinclude",
+                },
+              ],
               "resourceType": "MedicationRequest",
               "searchParams": Array [],
             }

--- a/src/FhirQueryParser/index.ts
+++ b/src/FhirQueryParser/index.ts
@@ -16,11 +16,7 @@ import { parseTokenSearchValue, TokenSearchValue } from './typeParsers/tokenPars
 import { NumberSearchValue, parseNumberSearchValue } from './typeParsers/numberParser';
 import { parseQuantitySearchValue, QuantitySearchValue } from './typeParsers/quantityParser';
 import { parseReferenceSearchValue, ReferenceSearchValue } from './typeParsers/referenceParser';
-import {
-    InclusionSearchParameter,
-    WildcardInclusionSearchParameter,
-    InclusionSearchParameterType,
-} from '../searchInclusions';
+import { InclusionSearchParameter, WildcardInclusionSearchParameter } from '../searchInclusions';
 import { parseInclusionParams } from './searchInclusion';
 
 export { DateSearchValue, TokenSearchValue, NumberSearchValue, QuantitySearchValue };

--- a/src/FhirQueryParser/searchInclusion.test.ts
+++ b/src/FhirQueryParser/searchInclusion.test.ts
@@ -1,0 +1,130 @@
+import each from 'jest-each';
+import { InvalidSearchParameterError } from 'fhir-works-on-aws-interface';
+import { inclusionParameterFromString, parseInclusionParams } from './searchInclusion';
+import { FHIRSearchParametersRegistry } from '../FHIRSearchParametersRegistry';
+import { InclusionSearchParameter, WildcardInclusionSearchParameter } from '../searchInclusions';
+
+const fhirSearchParametersRegistry = new FHIRSearchParametersRegistry('4.0.1');
+
+describe('inclusionParameterFromString', () => {
+    describe('invalid inclusion parameters', () => {
+        each([
+            ['some-invalid-param'],
+            ['Patient'],
+            ['Patient:'],
+            ['Patient:bad-field,,$'],
+            ['Patient:field:'],
+            ['Patient:field:bad#'],
+        ]).test('%s', (s: string) => {
+            expect(() => inclusionParameterFromString(s)).toThrow(
+                new InvalidSearchParameterError(`Invalid include/revinclude search parameter: ${s}`),
+            );
+        });
+    });
+    describe('valid inclusion parameters', () => {
+        test('optional target resource type missing', () => {
+            const input = 'Patient:field';
+            const expected = {
+                isWildcard: false,
+                sourceResource: 'Patient',
+                searchParameter: 'field',
+            };
+            expect(inclusionParameterFromString(input)).toEqual(expected);
+        });
+
+        test('optional target resource type present', () => {
+            const input = 'Patient:field:OtherResource';
+            const expected = {
+                isWildcard: false,
+                sourceResource: 'Patient',
+                searchParameter: 'field',
+                targetResourceType: 'OtherResource',
+            };
+            expect(inclusionParameterFromString(input)).toEqual(expected);
+        });
+
+        test('wildcard', () => {
+            const input = '*';
+            const expected = {
+                isWildcard: true,
+            };
+            expect(inclusionParameterFromString(input)).toEqual(expected);
+        });
+    });
+});
+
+describe('parseInclusionParams', () => {
+    test('No inclusion Params', () => {
+        const expected: any[] = [];
+        expect(parseInclusionParams(fhirSearchParametersRegistry, '_include', [])).toEqual(expected);
+    });
+    test('string param', () => {
+        const expected: (InclusionSearchParameter | WildcardInclusionSearchParameter)[] = [
+            {
+                isWildcard: false,
+                type: '_include',
+                sourceResource: 'Patient',
+                searchParameter: 'organization',
+                path: 'managingOrganization',
+                targetResourceType: undefined,
+            },
+        ];
+        expect(parseInclusionParams(fhirSearchParametersRegistry, '_include', ['Patient:organization'])).toEqual(
+            expected,
+        );
+    });
+    test('array param', () => {
+        const expected: InclusionSearchParameter[] = [
+            {
+                isWildcard: false,
+                isIterate: true,
+                type: '_revinclude',
+                sourceResource: 'Patient',
+                searchParameter: 'organization',
+                targetResourceType: undefined,
+                path: 'managingOrganization',
+            },
+            {
+                isWildcard: false,
+                isIterate: true,
+                type: '_revinclude',
+                searchParameter: 'general-practitioner',
+                targetResourceType: undefined,
+                path: 'generalPractitioner',
+                sourceResource: 'Patient',
+            },
+        ];
+        expect(
+            parseInclusionParams(fhirSearchParametersRegistry, '_revinclude:iterate', [
+                'Patient:organization',
+                'Patient:organization',
+                'Patient:general-practitioner',
+            ]),
+        ).toEqual(expected);
+    });
+    test('Invalid search param', () => {
+        expect(() =>
+            parseInclusionParams(fhirSearchParametersRegistry, '_include', ['Patient:invalid-search-param']),
+        ).toThrow(
+            new InvalidSearchParameterError(
+                'Invalid include/revinclude search parameter: Search parameter invalid-search-param does not exist in resource Patient',
+            ),
+        );
+    });
+    test('Search param is not of type reference', () => {
+        expect(() => parseInclusionParams(fhirSearchParametersRegistry, '_include', ['Patient:name'])).toThrow(
+            new InvalidSearchParameterError(
+                'Invalid include/revinclude search parameter: Search parameter name is not of type reference in resource Patient',
+            ),
+        );
+    });
+    test('Search param target resource type do not match', () => {
+        expect(() =>
+            parseInclusionParams(fhirSearchParametersRegistry, '_include', ['Patient:organization:Location']),
+        ).toThrow(
+            new InvalidSearchParameterError(
+                'Invalid include/revinclude search parameter: Search parameter organization in resource Patient does not point to target resource type Location',
+            ),
+        );
+    });
+});

--- a/src/FhirQueryParser/searchInclusion.ts
+++ b/src/FhirQueryParser/searchInclusion.ts
@@ -1,0 +1,60 @@
+import { uniq } from 'lodash';
+import { InvalidSearchParameterError } from 'fhir-works-on-aws-interface';
+import {
+    InclusionSearchParameter,
+    WildcardInclusionSearchParameter,
+    InclusionSearchParameterType,
+} from '../searchInclusions';
+import { FHIRSearchParametersRegistry } from '../FHIRSearchParametersRegistry';
+
+export const inclusionParameterFromString = (
+    s: string,
+): Omit<InclusionSearchParameter, 'type'> | Omit<WildcardInclusionSearchParameter, 'type'> => {
+    if (s === '*') {
+        return { isWildcard: true };
+    }
+    const INCLUSION_PARAM_REGEX =
+        /^(?<sourceResource>[A-Za-z]+):(?<searchParameter>[A-Za-z-]+)(?::(?<targetResourceType>[A-Za-z]+))?$/;
+    const match = s.match(INCLUSION_PARAM_REGEX);
+    if (match === null) {
+        throw new InvalidSearchParameterError(`Invalid include/revinclude search parameter: ${s}`);
+    }
+    const { sourceResource, searchParameter, targetResourceType } = match.groups!;
+    return {
+        isWildcard: false,
+        sourceResource,
+        searchParameter,
+        targetResourceType,
+    };
+};
+
+export const parseInclusionParams = (
+    fhirSearchParametersRegistry: FHIRSearchParametersRegistry,
+    searchParameter: string,
+    value: string[],
+): (InclusionSearchParameter | WildcardInclusionSearchParameter)[] => {
+    return uniq(value).map((v) => {
+        const inclusionParam = inclusionParameterFromString(v);
+        const colonIndex = searchParameter.indexOf(':') === -1 ? searchParameter.length : searchParameter.indexOf(':');
+        const type = searchParameter.substring(0, colonIndex) as '_include' | '_revinclude';
+        const isIterate = searchParameter.substring(colonIndex + 1) === 'iterate' ? true : undefined;
+        if (!inclusionParam.isWildcard) {
+            const searchParam = fhirSearchParametersRegistry.getReferenceSearchParameter(
+                inclusionParam.sourceResource,
+                inclusionParam.searchParameter,
+                inclusionParam.targetResourceType,
+            );
+            if ('error' in searchParam) {
+                throw new InvalidSearchParameterError(
+                    `Invalid include/revinclude search parameter: ${searchParam.error}`,
+                );
+            }
+            inclusionParam.path = searchParam.compiled[0].path;
+        }
+        return {
+            type,
+            ...(isIterate && { isIterate }),
+            ...inclusionParam,
+        };
+    });
+};

--- a/src/FhirQueryParser/searchInclusion.ts
+++ b/src/FhirQueryParser/searchInclusion.ts
@@ -1,10 +1,6 @@
 import { uniq } from 'lodash';
 import { InvalidSearchParameterError } from 'fhir-works-on-aws-interface';
-import {
-    InclusionSearchParameter,
-    WildcardInclusionSearchParameter,
-    InclusionSearchParameterType,
-} from '../searchInclusions';
+import { InclusionSearchParameter, WildcardInclusionSearchParameter } from '../searchInclusions';
 import { FHIRSearchParametersRegistry } from '../FHIRSearchParametersRegistry';
 
 export const inclusionParameterFromString = (

--- a/src/QueryBuilder/index.ts
+++ b/src/QueryBuilder/index.ts
@@ -19,6 +19,7 @@ import {
     ParsedFhirQueryParams,
     parseQuery,
     QuantitySearchValue,
+    QueryParam,
     TokenSearchValue,
 } from '../FhirQueryParser';
 import { ReferenceSearchValue } from '../FhirQueryParser/typeParsers/referenceParser';
@@ -135,17 +136,12 @@ function searchParamQuery(
 export const buildQueryForAllSearchParameters = (
     fhirSearchParametersRegistry: FHIRSearchParametersRegistry,
     request: TypeSearchRequest,
+    searchParams: QueryParam[],
     useKeywordSubFields: boolean,
     additionalFilters: any[] = [],
     chainedParameterQuery: any = {},
 ): any => {
-    const parsedFhirQueryParams: ParsedFhirQueryParams = parseQuery(
-        fhirSearchParametersRegistry,
-        request.resourceType,
-        request.queryParams,
-    );
-
-    const esQuery = parsedFhirQueryParams.searchParams.map((queryParam) => {
+    const esQuery = searchParams.map((queryParam) => {
         return searchParamQuery(
             queryParam.searchParam,
             queryParam.parsedSearchValues,

--- a/src/__snapshots__/elasticSearchService.test.ts.snap
+++ b/src/__snapshots__/elasticSearchService.test.ts.snap
@@ -780,35 +780,6 @@ Array [
 ]
 `;
 
-exports[`typeSearch _revinclude queryParams={"_revinclude":"MedicationAdministration:request:Device"}: msearch queries 1`] = `Array []`;
-
-exports[`typeSearch _revinclude queryParams={"_revinclude":"MedicationAdministration:request:Device"}: search queries 1`] = `
-Array [
-  Array [
-    Object {
-      "body": Object {
-        "query": Object {
-          "bool": Object {
-            "filter": Array [
-              Object {
-                "match": Object {
-                  "someFieldThatTellsIfTheResourceIsActive": "AVAILABLE",
-                },
-              },
-            ],
-            "must": Array [],
-          },
-        },
-      },
-      "from": 0,
-      "index": "medicationrequest-alias",
-      "size": 20,
-      "track_total_hits": true,
-    },
-  ],
-]
-`;
-
 exports[`typeSearch _revinclude queryParams={"_revinclude":"MedicationAdministration:request:MedicationRequest"}: msearch queries 1`] = `
 Array [
   Array [

--- a/src/elasticSearchService.test.ts
+++ b/src/elasticSearchService.test.ts
@@ -506,7 +506,6 @@ describe('typeSearch', () => {
             [{ _revinclude: '*' }],
             [{ _revinclude: 'MedicationAdministration:request' }],
             [{ _revinclude: 'MedicationAdministration:request:MedicationRequest' }],
-            // [{ _revinclude: 'MedicationAdministration:request:Device' }],
             [{ _revinclude: ['MedicationAdministration:request', 'Provenance:target'] }],
             [{ _revinclude: ['MedicationAdministration:request', 'MedicationAdministration:request'] }],
         ]).test('queryParams=%j', async (queryParams: any) => {

--- a/src/elasticSearchService.test.ts
+++ b/src/elasticSearchService.test.ts
@@ -506,7 +506,7 @@ describe('typeSearch', () => {
             [{ _revinclude: '*' }],
             [{ _revinclude: 'MedicationAdministration:request' }],
             [{ _revinclude: 'MedicationAdministration:request:MedicationRequest' }],
-            [{ _revinclude: 'MedicationAdministration:request:Device' }],
+            // [{ _revinclude: 'MedicationAdministration:request:Device' }],
             [{ _revinclude: ['MedicationAdministration:request', 'Provenance:target'] }],
             [{ _revinclude: ['MedicationAdministration:request', 'MedicationAdministration:request'] }],
         ]).test('queryParams=%j', async (queryParams: any) => {

--- a/src/searchInclusions.test.ts
+++ b/src/searchInclusions.test.ts
@@ -1,94 +1,9 @@
-import each from 'jest-each';
+// import each from 'jest-each';
 import {
-    inclusionParameterFromString,
-    getInclusionParametersFromQueryParams,
     getIncludeReferencesFromResources,
     getRevincludeReferencesFromResources,
     InclusionSearchParameter,
 } from './searchInclusions';
-
-describe('inclusionParameterFromString', () => {
-    describe('invalid inclusion parameters', () => {
-        each([
-            ['some-invalid-param'],
-            ['Patient'],
-            ['Patient:'],
-            ['Patient:bad-field,,$'],
-            ['Patient:field:'],
-            ['Patient:field:bad#'],
-        ]).test('%s', (s: string) => {
-            expect(inclusionParameterFromString(s)).toBeNull();
-        });
-    });
-    describe('valid inclusion parameters', () => {
-        test('optional target resource type missing', () => {
-            const input = 'Patient:field';
-            const expected = {
-                isWildcard: false,
-                sourceResource: 'Patient',
-                searchParameter: 'field',
-            };
-            expect(inclusionParameterFromString(input)).toEqual(expected);
-        });
-
-        test('optional target resource type present', () => {
-            const input = 'Patient:field:OtherResource';
-            const expected = {
-                isWildcard: false,
-                sourceResource: 'Patient',
-                searchParameter: 'field',
-                targetResourceType: 'OtherResource',
-            };
-            expect(inclusionParameterFromString(input)).toEqual(expected);
-        });
-
-        test('wildcard', () => {
-            const input = '*';
-            const expected = {
-                isWildcard: true,
-            };
-            expect(inclusionParameterFromString(input)).toEqual(expected);
-        });
-    });
-});
-
-describe('getInclusionParametersFromQueryParams', () => {
-    test('No inclusion Params', () => {
-        const queryParams = { someKey: 'someValue' };
-        const expected: any[] = [];
-        expect(getInclusionParametersFromQueryParams('_include', queryParams)).toEqual(expected);
-    });
-    test('string param', () => {
-        const queryParams = { someKey: 'someValue', _include: 'Patient:someField' };
-        const expected: InclusionSearchParameter[] = [
-            {
-                isWildcard: false,
-                type: '_include',
-                sourceResource: 'Patient',
-                searchParameter: 'someField',
-            },
-        ];
-        expect(getInclusionParametersFromQueryParams('_include', queryParams)).toEqual(expected);
-    });
-    test('array param', () => {
-        const queryParams = { someKey: 'someValue', _include: ['Patient:someField', 'Practitioner:someField'] };
-        const expected: InclusionSearchParameter[] = [
-            {
-                isWildcard: false,
-                type: '_include',
-                sourceResource: 'Patient',
-                searchParameter: 'someField',
-            },
-            {
-                isWildcard: false,
-                type: '_include',
-                sourceResource: 'Practitioner',
-                searchParameter: 'someField',
-            },
-        ];
-        expect(getInclusionParametersFromQueryParams('_include', queryParams)).toEqual(expected);
-    });
-});
 
 describe('getIncludeReferencesFromResources', () => {
     test('Happy case', () => {


### PR DESCRIPTION
Issue #, if available:

Description of changes:

* Refactor inclusion logic so inclusion search param is parsed under FhirQueryParser
* Wildcard inclusion search param is parsed after main search is run as main search outcome is needed for parsing wildcard param
* Strictly validate inclusion search params 
* Valid inclusion search params are treated exactly the same as before 
* Deployed and tested in AWS Account 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.